### PR TITLE
Allow to specify the port of the api servers

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -6,6 +6,7 @@ resource "template_dir" "bootstrap-manifests" {
   vars {
     hyperkube_image = "${var.container_images["hyperkube"]}"
     etcd_servers    = "${var.experimental_self_hosted_etcd ? format("https://%s:2379,https://127.0.0.1:12379", cidrhost(var.service_cidr, 15)) : join(",", formatlist("https://%s:2379", var.etcd_servers))}"
+    api_port        = "${var.api_port}"
 
     cloud_provider = "${var.cloud_provider}"
     pod_cidr       = "${var.pod_cidr}"
@@ -21,6 +22,7 @@ resource "template_dir" "manifests" {
   vars {
     hyperkube_image = "${var.container_images["hyperkube"]}"
     etcd_servers    = "${var.experimental_self_hosted_etcd ? format("https://%s:2379", cidrhost(var.service_cidr, 15)) : join(",", formatlist("https://%s:2379", var.etcd_servers))}"
+    api_port        = "${var.api_port}"
 
     cloud_provider      = "${var.cloud_provider}"
     pod_cidr            = "${var.pod_cidr}"
@@ -58,7 +60,7 @@ data "template_file" "kubeconfig" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:443", element(var.api_servers, 0))}"
+    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.api_port)}"
   }
 }
 
@@ -70,6 +72,6 @@ data "template_file" "user-kubeconfig" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:443", element(var.api_servers, 0))}"
+    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.api_port)}"
   }
 }

--- a/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -26,7 +26,7 @@ spec:
     - --insecure-port=0
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-    - --secure-port=443
+    - --secure-port=${api_port}
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
     - --service-cluster-ip-range=${service_cidr}
     - --cloud-provider=${cloud_provider}

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -40,7 +40,7 @@ spec:
         - --insecure-port=0
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-        - --secure-port=443
+        - --secure-port=${api_port}
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --service-cluster-ip-range=${service_cidr}
         - --storage-backend=etcd3

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "api_servers" {
   type        = "list"
 }
 
+variable "api_port" {
+  description = "Port used to reach kube-apiserver"
+  type        = "string"
+  default     = "443"
+}
+
 variable "etcd_servers" {
   description = "List of URLs used to reach etcd servers. Ignored if experimental self-hosted etcd is enabled."
   type        = "list"


### PR DESCRIPTION
Allow to specify another port than 443 for the API servers.
For example kubeadm use the port 6443 instead of 443.