### PR TITLE
Add 127.0.0.1 to k8s apiserver cert like bootkube

### DIFF
--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -74,6 +74,7 @@ resource "tls_cert_request" "apiserver" {
   ]
 
   ip_addresses = [
+    "127.0.0.1",
     "${cidrhost(var.service_cidr, 1)}",
   ]
 }


### PR DESCRIPTION
Allow to use 127.0.0.1 to access k8s api like bootkube allowed