### PR TITLE
Render images from the container_images map variable

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -19,8 +19,13 @@ resource "template_dir" "manifests" {
   destination_dir = "${var.asset_dir}/manifests"
 
   vars {
-    hyperkube_image = "${var.container_images["hyperkube"]}"
-    etcd_servers    = "${var.experimental_self_hosted_etcd ? format("https://%s:2379", cidrhost(var.service_cidr, 15)) : join(",", formatlist("https://%s:2379", var.etcd_servers))}"
+    hyperkube_image        = "${var.container_images["hyperkube"]}"
+    pod_checkpointer_image = "${var.container_images["pod_checkpointer"]}"
+    kubedns_image          = "${var.container_images["kubedns"]}"
+    kubedns_dnsmasq_image  = "${var.container_images["kubedns_dnsmasq"]}"
+    kubedns_sidecar_image  = "${var.container_images["kubedns_sidecar"]}"
+
+    etcd_servers = "${var.experimental_self_hosted_etcd ? format("https://%s:2379", cidrhost(var.service_cidr, 15)) : join(",", formatlist("https://%s:2379", var.etcd_servers))}"
 
     cloud_provider      = "${var.cloud_provider}"
     pod_cidr            = "${var.pod_cidr}"

--- a/conditional.tf
+++ b/conditional.tf
@@ -6,6 +6,9 @@ resource "template_dir" "flannel-manifests" {
   destination_dir = "${var.asset_dir}/manifests-networking"
 
   vars {
+    flannel_image     = "${var.container_images["flannel"]}"
+    flannel_cni_image = "${var.container_images["flannel_cni"]}"
+
     pod_cidr = "${var.pod_cidr}"
   }
 }
@@ -16,6 +19,9 @@ resource "template_dir" "calico-manifests" {
   destination_dir = "${var.asset_dir}/manifests-networking"
 
   vars {
+    calico_image     = "${var.container_images["calico"]}"
+    calico_cni_image = "${var.container_images["calico_cni"]}"
+
     network_mtu = "${var.network_mtu}"
     pod_cidr    = "${var.pod_cidr}"
   }
@@ -52,7 +58,9 @@ resource "template_dir" "experimental-manifests" {
   destination_dir = "${var.asset_dir}/experimental/manifests"
 
   vars {
-    etcd_service_ip = "${cidrhost(var.service_cidr, 15)}"
+    etcd_operator_image     = "${var.container_images["etcd_operator"]}"
+    etcd_checkpointer_image = "${var.container_images["etcd_checkpointer"]}"
+    etcd_service_ip         = "${cidrhost(var.service_cidr, 15)}"
 
     # Self-hosted etcd TLS certs / keys
     etcd_ca_cert     = "${base64encode(tls_self_signed_cert.etcd-ca.cert_pem)}"

--- a/resources/calico/calico.yaml
+++ b/resources/calico/calico.yaml
@@ -27,7 +27,7 @@ spec:
           operator: "Exists"
       containers:
         - name: calico-node
-          image: quay.io/calico/node:v2.6.1
+          image: ${calico_image}
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -99,7 +99,7 @@ spec:
               readOnly: false
         # Install Calico CNI binaries and CNI network config file on nodes
         - name: install-cni
-          image: quay.io/calico/cni:v1.11.0
+          image: ${calico_cni_image}
           command: ["/install-cni.sh"]
           env:
             - name: CNI_NETWORK_CONFIG

--- a/resources/experimental/manifests/etcd-operator.yaml
+++ b/resources/experimental/manifests/etcd-operator.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.5.0
+        image: ${etcd_operator_image}
         command:
         - /usr/local/bin/etcd-operator
         - --analytics=false

--- a/resources/experimental/manifests/kube-etcd-network-checkpointer.yaml
+++ b/resources/experimental/manifests/kube-etcd-network-checkpointer.yaml
@@ -16,7 +16,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       containers:
-      - image: quay.io/coreos/kenc:0.0.2
+      - image: ${etcd_checkpointer_image}
         name: kube-etcd-network-checkpointer
         securityContext:
           privileged: true

--- a/resources/flannel/kube-flannel.yaml
+++ b/resources/flannel/kube-flannel.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.8.0-amd64
+        image: ${flannel_image}
         command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr", "--iface=$(POD_IP)"]
         securityContext:
           privileged: true
@@ -40,7 +40,7 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: quay.io/coreos/flannel-cni:v0.3.0
+        image: ${flannel_cni_image}
         command: ["/install-cni.sh"]
         env:
         - name: CNI_NETWORK_CONFIG

--- a/resources/manifests/kube-dns-deployment.yaml
+++ b/resources/manifests/kube-dns-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5
+        image: ${kubedns_image}
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -92,7 +92,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+        image: ${kubedns_dnsmasq_image}
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -130,7 +130,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5
+        image: ${kubedns_sidecar_image}
         livenessProbe:
           httpGet:
             path: /metrics

--- a/resources/manifests/pod-checkpointer.yaml
+++ b/resources/manifests/pod-checkpointer.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: pod-checkpointer
-        image: quay.io/coreos/pod-checkpointer:abdcbc46df985b832cccf805b34f4652a0ca9d56
+        image: ${pod_checkpointer_image}
         command:
         - /checkpoint
         - --v=4

--- a/variables.tf
+++ b/variables.tf
@@ -62,8 +62,18 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    hyperkube = "quay.io/coreos/hyperkube:v1.7.7_coreos.0"
-    etcd      = "quay.io/coreos/etcd:v3.1.8"
+    calico            = "quay.io/calico/node:v2.6.1"
+    calico_cni        = "quay.io/calico/cni:v1.11.0"
+    etcd              = "quay.io/coreos/etcd:v3.1.8"
+    etcd_operator     = "quay.io/coreos/etcd-operator:v0.5.0"
+    etcd_checkpointer = "quay.io/coreos/kenc:0.0.2"
+    flannel           = "quay.io/coreos/flannel:v0.8.0-amd64"
+    flannel_cni       = "quay.io/coreos/flannel-cni:v0.3.0"
+    hyperkube         = "quay.io/coreos/hyperkube:v1.7.7_coreos.0"
+    kubedns           = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
+    kubedns_dnsmasq   = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
+    kubedns_sidecar   = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
+    pod_checkpointer  = "quay.io/coreos/pod-checkpointer:abdcbc46df985b832cccf805b34f4652a0ca9d56"
   }
 }
 


### PR DESCRIPTION
* Move remaining manifest images into the `container_images` map variable
* Container images may be customized to facilitate mirroring images to alternative registries or development with custom images.

```
module "bootkube" {
  source = "git::https://github.com/poseidon/terraform-render-bootkube.git?ref=SHA"

  cluster_name                  = "${var.cluster_name}"
  api_servers                   = ["${var.k8s_domain_name}"]
  etcd_servers                  = ["${var.controller_domains}"]
  asset_dir                     = "${var.asset_dir}"
  networking                    = "${var.networking}"
  network_mtu                   = "${var.network_mtu}"
  pod_cidr                      = "${var.pod_cidr}"
  service_cidr                  = "${var.service_cidr}"
  container_images = {
    calico            = "quay.io/calico/node:v2.6.1"
    calico_cni        = "quay.io/calico/cni:v1.11.0"
    etcd              = "quay.io/coreos/etcd:v3.1.8"
    etcd_operator     = "quay.io/coreos/etcd-operator:v0.5.0"
    etcd_checkpointer = "quay.io/coreos/kenc:0.0.2"
    flannel           = "quay.io/coreos/flannel:v0.8.0-amd64"
    flannel_cni       = "quay.io/coreos/flannel-cni:v0.3.0"
    hyperkube         = "quay.io/coreos/hyperkube:v1.7.7_coreos.0"
    pod_checkpointer  = "quay.io/coreos/pod-checkpointer:abdcbc46df985b832cccf805b34f4652a0ca9d56"
    kubedns           = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
    kubedns_dnsmasq   = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
    kubedns_sidecar   = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
  }
}
```

Note:

* This is not intended to provide out-of-box support for local registries. That is a separate exercise.

Closes #23