### PR TITLE
Update assets generation for bootkube v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Find bootkube assets rendered to the `asset_dir` path. That's it.
 
 ### Comparison
 
-Render bootkube assets directly with bootkube v0.7.0.
+Render bootkube assets directly with bootkube v0.8.0.
 
 #### On-host etcd (recommended)
 

--- a/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -12,7 +12,7 @@ spec:
     - /var/lock/api-server.lock
     - /hyperkube
     - apiserver
-    - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
+    - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
     - --advertise-address=$(POD_IP)
     - --allow-privileged=true
     - --authorization-mode=RBAC

--- a/resources/calico/calico-cluster-role-binding.yaml
+++ b/resources/calico/calico-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node

--- a/resources/calico/calico-cluster-role.yaml
+++ b/resources/calico/calico-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: calico-node

--- a/resources/calico/calico.yaml
+++ b/resources/calico/calico.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: calico-node

--- a/resources/experimental/manifests/etcd-operator.yaml
+++ b/resources/experimental/manifests/etcd-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: etcd-operator
@@ -6,12 +6,10 @@ metadata:
   labels:
     k8s-app: etcd-operator
 spec:
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 1
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: etcd-operator
   template:
     metadata:
       labels:
@@ -41,3 +39,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1

--- a/resources/experimental/manifests/kube-etcd-network-checkpointer.yaml
+++ b/resources/experimental/manifests/kube-etcd-network-checkpointer.yaml
@@ -1,4 +1,4 @@
-apiVersion: "extensions/v1beta1"
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: kube-etcd-network-checkpointer
@@ -7,6 +7,10 @@ metadata:
     tier: control-plane
     k8s-app: kube-etcd-network-checkpointer
 spec:
+  selector:
+    matchLabels:
+      tier: control-plane
+      k8s-app: kube-etcd-network-checkpointer
   template:
     metadata:
       labels:

--- a/resources/flannel/kube-flannel.yaml
+++ b/resources/flannel/kube-flannel.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: kube-flannel
@@ -7,6 +7,10 @@ metadata:
     tier: node
     k8s-app: flannel
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      k8s-app: flannel
   template:
     metadata:
       labels:

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -1,4 +1,4 @@
-apiVersion: "extensions/v1beta1"
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: kube-apiserver
@@ -7,6 +7,10 @@ metadata:
     tier: control-plane
     k8s-app: kube-apiserver
 spec:
+  selector:
+    matchLabels:
+      tier: control-plane
+      k8s-app: kube-apiserver
   template:
     metadata:
       labels:
@@ -24,7 +28,7 @@ spec:
         - /var/lock/api-server.lock
         - /hyperkube
         - apiserver
-        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
+        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
         - --advertise-address=$(POD_IP)
         - --allow-privileged=true
         - --anonymous-auth=false

--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: kube-controller-manager
@@ -8,6 +8,10 @@ metadata:
     k8s-app: kube-controller-manager
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      tier: control-plane
+      k8s-app: kube-controller-manager
   template:
     metadata:
       labels:

--- a/resources/manifests/kube-dns-deployment.yaml
+++ b/resources/manifests/kube-dns-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: kube-dns

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: "extensions/v1beta1"
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: kube-proxy
@@ -7,6 +7,10 @@ metadata:
     tier: node
     k8s-app: kube-proxy
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      k8s-app: kube-proxy
   template:
     metadata:
       labels:

--- a/resources/manifests/kube-scheduler.yaml
+++ b/resources/manifests/kube-scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: kube-scheduler
@@ -8,6 +8,10 @@ metadata:
     k8s-app: kube-scheduler
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      tier: control-plane
+      k8s-app: kube-scheduler
   template:
     metadata:
       labels:

--- a/resources/manifests/kube-system-rbac-role-binding.yaml
+++ b/resources/manifests/kube-system-rbac-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:default-sa

--- a/resources/manifests/pod-checkpointer.yaml
+++ b/resources/manifests/pod-checkpointer.yaml
@@ -1,4 +1,4 @@
-apiVersion: "extensions/v1beta1"
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: pod-checkpointer
@@ -7,6 +7,10 @@ metadata:
     tier: control-plane
     k8s-app: pod-checkpointer
 spec:
+  selector:
+    matchLabels:
+      tier: control-plane
+      k8s-app: pod-checkpointer
   template:
     metadata:
       labels:

--- a/variables.tf
+++ b/variables.tf
@@ -69,11 +69,11 @@ variable "container_images" {
     etcd_checkpointer = "quay.io/coreos/kenc:0.0.2"
     flannel           = "quay.io/coreos/flannel:v0.8.0-amd64"
     flannel_cni       = "quay.io/coreos/flannel-cni:v0.3.0"
-    hyperkube         = "quay.io/coreos/hyperkube:v1.7.7_coreos.0"
+    hyperkube         = "quay.io/coreos/hyperkube:v1.8.1_coreos.0"
     kubedns           = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
     kubedns_dnsmasq   = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
     kubedns_sidecar   = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
-    pod_checkpointer  = "quay.io/coreos/pod-checkpointer:abdcbc46df985b832cccf805b34f4652a0ca9d56"
+    pod_checkpointer  = "quay.io/coreos/pod-checkpointer:ec22bec63334befacc2b237ab73b1a8b95b0a654"
   }
 }
 


### PR DESCRIPTION
* Update from Kubernetes v1.7.7 to v1.8.1
* Use bootkube v0.8.0 https://github.com/kubernetes-incubator/bootkube/releases/tag/v0.8.0