### PR TITLE
Kubernetes v1.8.2, gcr.io, flannel v0.9.0, hairpin, and no-negcache

### DIFF
--- a/resources/flannel/kube-flannel-cfg.yaml
+++ b/resources/flannel/kube-flannel-cfg.yaml
@@ -15,6 +15,7 @@ data:
         {
           "type": "flannel",
           "delegate": {
+            "hairpinMode": true,
             "isDefaultGateway": true
           }
         },

--- a/resources/manifests/kube-dns-deployment.yaml
+++ b/resources/manifests/kube-dns-deployment.yaml
@@ -110,6 +110,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/cluster.local/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/variables.tf
+++ b/variables.tf
@@ -69,7 +69,7 @@ variable "container_images" {
     etcd_checkpointer = "quay.io/coreos/kenc:0.0.2"
     flannel           = "quay.io/coreos/flannel:v0.9.0-amd64"
     flannel_cni       = "quay.io/coreos/flannel-cni:v0.3.0"
-    hyperkube         = "quay.io/coreos/hyperkube:v1.8.1_coreos.0"
+    hyperkube         = "gcr.io/google_containers/hyperkube:v1.8.1"
     kubedns           = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
     kubedns_dnsmasq   = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
     kubedns_sidecar   = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "container_images" {
     etcd              = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator     = "quay.io/coreos/etcd-operator:v0.5.0"
     etcd_checkpointer = "quay.io/coreos/kenc:0.0.2"
-    flannel           = "quay.io/coreos/flannel:v0.8.0-amd64"
+    flannel           = "quay.io/coreos/flannel:v0.9.0-amd64"
     flannel_cni       = "quay.io/coreos/flannel-cni:v0.3.0"
     hyperkube         = "quay.io/coreos/hyperkube:v1.8.1_coreos.0"
     kubedns           = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"

--- a/variables.tf
+++ b/variables.tf
@@ -69,7 +69,7 @@ variable "container_images" {
     etcd_checkpointer = "quay.io/coreos/kenc:0.0.2"
     flannel           = "quay.io/coreos/flannel:v0.9.0-amd64"
     flannel_cni       = "quay.io/coreos/flannel-cni:v0.3.0"
-    hyperkube         = "gcr.io/google_containers/hyperkube:v1.8.1"
+    hyperkube         = "gcr.io/google_containers/hyperkube:v1.8.2"
     kubedns           = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
     kubedns_dnsmasq   = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
     kubedns_sidecar   = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"


### PR DESCRIPTION
* Switch to using the official upstream `gcr.io/google_containers/hyperkube`
* Update from Kubernetes v1.8.1 to v1.8.2 (includes memory leak fix https://github.com/kubernetes/kubernetes/pull/54225)
* Update from flannel v0.8.0 to v0.9.0
* Add hairpinMode in flannel CNI config
* Add `--no-negcache to dnsmasq args`

It is recommended that users switch the on-host kubelet to also use the corresponding `gcr.io/google_containers/hyperkube` image.