### PR TITLE
Sync with upstream bootkube changes

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,10 +10,6 @@ output "kube_dns_service_ip" {
   value = "${cidrhost(var.service_cidr, 10)}"
 }
 
-output "etcd_service_ip" {
-  value = "${cidrhost(var.service_cidr, 15)}"
-}
-
 output "kubeconfig" {
   value = "${data.template_file.kubeconfig.rendered}"
 }

--- a/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -12,6 +12,7 @@ spec:
     - controller-manager
     - --allocate-node-cidrs=true
     - --cluster-cidr=${pod_cidr}
+    - --service-cluster-ip-range=${service_cidr}
     - --cloud-provider=${cloud_provider}
     - --configure-cloud-routes=false
     - --kubeconfig=/etc/kubernetes/kubeconfig

--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -43,6 +43,7 @@ spec:
         - --allocate-node-cidrs=true
         - --cloud-provider=${cloud_provider}
         - --cluster-cidr=${pod_cidr}
+        - --service-cluster-ip-range=${service_cidr}
         - --configure-cloud-routes=false
         - --leader-elect=true
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt

--- a/resources/manifests/pod-checkpointer-role-binding.yaml
+++ b/resources/manifests/pod-checkpointer-role-binding.yaml
@@ -1,10 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: pod-checkpointer
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: pod-checkpointer
 subjects:
 - kind: ServiceAccount

--- a/resources/manifests/pod-checkpointer-role.yaml
+++ b/resources/manifests/pod-checkpointer-role.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: pod-checkpointer
+  namespace: kube-system
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]

--- a/tls-etcd.tf
+++ b/tls-etcd.tf
@@ -96,16 +96,12 @@ resource "tls_cert_request" "client" {
 
   ip_addresses = [
     "127.0.0.1",
-    "${cidrhost(var.service_cidr, 15)}",
-    "${cidrhost(var.service_cidr, 20)}",
   ]
 
   dns_names = ["${concat(
     var.etcd_servers,
     list(
       "localhost",
-      "*.kube-etcd.kube-system.svc.cluster.local",
-      "kube-etcd-client.kube-system.svc.cluster.local",
     ))}"]
 }
 
@@ -142,16 +138,12 @@ resource "tls_cert_request" "server" {
 
   ip_addresses = [
     "127.0.0.1",
-    "${cidrhost(var.service_cidr, 15)}",
-    "${cidrhost(var.service_cidr, 20)}",
   ]
 
   dns_names = ["${concat(
     var.etcd_servers,
     list(
       "localhost",
-      "*.kube-etcd.kube-system.svc.cluster.local",
-      "kube-etcd-client.kube-system.svc.cluster.local",
     ))}"]
 }
 
@@ -186,16 +178,7 @@ resource "tls_cert_request" "peer" {
     organization = "etcd"
   }
 
-  ip_addresses = [
-    "${cidrhost(var.service_cidr, 20)}",
-  ]
-
-  dns_names = ["${concat(
-    var.etcd_servers,
-    list(
-      "*.kube-etcd.kube-system.svc.cluster.local",
-      "kube-etcd-client.kube-system.svc.cluster.local",
-    ))}"]
+  dns_names = ["${var.etcd_servers}"]
 }
 
 resource "tls_locally_signed_cert" "peer" {

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "container_images" {
     kubedns           = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
     kubedns_dnsmasq   = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
     kubedns_sidecar   = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
-    pod_checkpointer  = "quay.io/coreos/pod-checkpointer:e22cc0e3714378de92f45326474874eb602ca0ac"
+    pod_checkpointer  = "quay.io/coreos/pod-checkpointer:08fa021813231323e121ecca7383cc64c4afe888"
   }
 }
 


### PR DESCRIPTION
* Add controller-manager flag for `service_cidr` (https://github.com/kubernetes-incubator/bootkube/pull/797)
  * controller-manager can handle overlapping pod and service CIDRs
to avoid address collisions, if its informed of both ranges
  * Still favor non-overlapping pod and service ranges of course
* Update pod-checkpointer and drop ClusterRole to Role (https://github.com/kubernetes-incubator/bootkube/pull/784)
  * pod-checkpointer no longer needs to watch pods in all namespaces, it should only have permission to watch kube-system
* Remove self-hosted etcd TLS cert SANs following #30