### PR TITLE
Parameterise KCM cidrs for non-cloud deployments and small networks

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -7,9 +7,11 @@ resource "template_dir" "bootstrap-manifests" {
     hyperkube_image = "${var.container_images["hyperkube"]}"
     etcd_servers    = "${join(",", formatlist("https://%s:2379", var.etcd_servers))}"
 
-    cloud_provider = "${var.cloud_provider}"
-    pod_cidr       = "${var.pod_cidr}"
-    service_cidr   = "${var.service_cidr}"
+    cloud_provider      = "${var.cloud_provider}"
+    pod_cidr            = "${var.pod_cidr}"
+    service_cidr        = "${var.service_cidr}"
+    node_mask_size      = "${var.node_mask_size}"
+    allocate_node_cidrs = "${var.allocate_node_cidrs}"
   }
 }
 
@@ -32,6 +34,8 @@ resource "template_dir" "manifests" {
     service_cidr          = "${var.service_cidr}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
     kube_dns_service_ip   = "${cidrhost(var.service_cidr, 10)}"
+    node_mask_size        = "${var.node_mask_size}"
+    allocate_node_cidrs   = "${var.allocate_node_cidrs}"
 
     ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     server             = "${format("https://%s:443", element(var.api_servers, 0))}"

--- a/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -10,7 +10,7 @@ spec:
     command:
     - ./hyperkube
     - controller-manager
-    - --allocate-node-cidrs=true
+    - --allocate-node-cidrs=${allocate_node_cidrs}
     - --cluster-cidr=${pod_cidr}
     - --service-cluster-ip-range=${service_cidr}
     - --cloud-provider=${cloud_provider}
@@ -19,6 +19,7 @@ spec:
     - --leader-elect=true
     - --root-ca-file=/etc/kubernetes/bootstrap-secrets/ca.crt
     - --service-account-private-key-file=/etc/kubernetes/bootstrap-secrets/service-account.key
+    - --node-cidr-mask-size=${node_mask_size}
     volumeMounts:
     - name: kubernetes
       mountPath: /etc/kubernetes

--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -40,7 +40,7 @@ spec:
         command:
         - ./hyperkube
         - controller-manager
-        - --allocate-node-cidrs=true
+        - --allocate-node-cidrs=${allocate_node_cidrs}
         - --cloud-provider=${cloud_provider}
         - --cluster-cidr=${pod_cidr}
         - --service-cluster-ip-range=${service_cidr}
@@ -48,6 +48,7 @@ spec:
         - --leader-elect=true
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+        - --node-cidr-mask-size=${node_mask_size}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,18 @@ EOD
   default = "10.3.0.0/24"
 }
 
+variable "node_mask_size" {
+  description = "Mask size for node cidr in cluster"
+  type        = "string"
+  default     = "24"
+}
+
+variable "allocate_node_cidrs" {
+  description = "Should CIDRs for Pods be allocated and set on the cloud provider"
+  type        = "string"
+  default     = "true"
+}
+
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by kube-dns"
   type        = "string"


### PR DESCRIPTION
My situation is similar to [this](https://github.com/kubernetes-incubator/kubespray/issues/1712). I need to use /26 cidr on a private cloud test network (which is the minimum for Calico) but get KCM errors since the default mask is /24 as per [this doc](https://kubernetes.io/docs/reference/generated/kube-controller-manager/), which is easily solvable by parameterising a couple of values.