### PR TITLE
Calico bump, update cniVersion, and enable portmap to fix hostPort

### DIFF
--- a/resources/calico/calico-config.yaml
+++ b/resources/calico/calico-config.yaml
@@ -7,23 +7,33 @@ data:
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
-        "name": "k8s-pod-network",
-        "cniVersion": "0.3.0",
-        "type": "calico",
-        "log_level": "info",
-        "datastore_type": "kubernetes",
-        "nodename": "__KUBERNETES_NODE_NAME__",
-        "mtu": ${network_mtu},
-        "ipam": {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": ${network_mtu},
+          "ipam": {
             "type": "host-local",
             "subnet": "usePodCidr"
-        },
-        "policy": {
+          },
+          "policy": {
             "type": "k8s",
             "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
+          },
+          "kubernetes": {
             "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
             "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
         }
+      ]
     }

--- a/resources/calico/calico.yaml
+++ b/resources/calico/calico.yaml
@@ -101,6 +101,8 @@ spec:
           image: ${calico_cni_image}
           command: ["/install-cni.sh"]
           env:
+            - name: CNI_CONF_NAME
+              value: 10-calico.conflist
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v2.6.4"
+    calico           = "quay.io/calico/node:v2.6.5"
     calico_cni       = "quay.io/calico/cni:v1.11.2"
     flannel          = "quay.io/coreos/flannel:v0.9.1-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"


### PR DESCRIPTION
* Enable portmap plugin to fix hostPort with Calico
* Ask the Calico sidecar to add a CNI conflist to each node (for calico and portmap plugins). Cleans up Switch from CNI conf to conflist
  * For context, we did the same change for Flannel recently. The sidecar lays down a conflist which configures both portmap and flannel

Related:

* https://github.com/projectcalico/cni-plugin/blob/v1.11.2/k8s-install/scripts/install-cni.sh
* Related kubernetes-incubator/bootkube#711
