### PR TITLE
Support extra flags and feature gates in kube manifests

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -43,6 +43,11 @@ resource "template_dir" "manifests" {
     etcd_ca_cert     = "${base64encode(tls_self_signed_cert.etcd-ca.cert_pem)}"
     etcd_client_cert = "${base64encode(tls_locally_signed_cert.client.cert_pem)}"
     etcd_client_key  = "${base64encode(tls_private_key.client.private_key_pem)}"
+
+    feature_gates                       = "${length(var.feature_gates) > 0 ? format("- --feature-gates=%s", join(",", formatlist("%s=true", var.feature_gates))) : ""}"
+    extra_flags_kube_apiserver          = "${indent(8, join("\n", formatlist("- %s", var.extra_flags_kube_apiserver)))}"
+    extra_flags_kube_scheduler          = "${indent(8, join("\n", formatlist("- %s", var.extra_flags_kube_scheduler)))}"
+    extra_flags_kube_controller_manager = "${indent(8, join("\n", formatlist("- %s", var.extra_flags_kube_controller_manager)))}"
   }
 }
 

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -48,6 +48,8 @@ spec:
         - --tls-ca-file=/etc/kubernetes/secrets/ca.crt
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
+        ${feature_gates}
+        ${extra_flags_kube_apiserver}
         env:
         - name: POD_IP
           valueFrom:

--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -49,6 +49,8 @@ spec:
         - --leader-elect=true
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+        ${feature_gates}
+        ${extra_flags_kube_controller_manager}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/resources/manifests/kube-scheduler.yaml
+++ b/resources/manifests/kube-scheduler.yaml
@@ -41,6 +41,8 @@ spec:
         - ./hyperkube
         - scheduler
         - --leader-elect=true
+        ${feature_gates}
+        ${extra_flags_kube_scheduler}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/variables.tf
+++ b/variables.tf
@@ -92,3 +92,27 @@ variable "ca_private_key" {
   type        = "string"
   default     = ""
 }
+
+variable "extra_flags_kube_apiserver" {
+  description = "List of extra flags for kube-apiserver"
+  type        = "list"
+  default     = []
+}
+
+variable "extra_flags_kube_scheduler" {
+  description = "List of extra flags for kube-scheduler"
+  type        = "list"
+  default     = []
+}
+
+variable "extra_flags_kube_controller_manager" {
+  description = "List of extra flags for kube-controller-manager"
+  type        = "list"
+  default     = []
+}
+
+variable "feature_gates" {
+  description = "List of feature gates"
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
This PR adds support for passing optional extra flags/feature gates to the the kube apiserver, controller-manager and scheduler.
 