### PR TITLE
Export user kubeconfig contents instead of just a file path

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "kubeconfig" {
 }
 
 output "user-kubeconfig" {
-  value = "${local_file.user-kubeconfig.filename}"
+  value = "${data.template_file.user-kubeconfig.rendered}"
 }
 
 # etcd TLS assets


### PR DESCRIPTION
The `user-kubeconfig` output is currently a path to the rendered file within bootkube assets. This change exports the contents of that file instead of the path to match what is currently done with the `kubeconfig` output. 