### PR TITLE
Allow specifying the Calico IP autodetection method

### DIFF
--- a/conditional.tf
+++ b/conditional.tf
@@ -22,7 +22,8 @@ resource "template_dir" "calico-manifests" {
     calico_image     = "${var.container_images["calico"]}"
     calico_cni_image = "${var.container_images["calico_cni"]}"
 
-    network_mtu = "${var.network_mtu}"
-    pod_cidr    = "${var.pod_cidr}"
+    network_mtu                     = "${var.network_mtu}"
+    network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
+    pod_cidr                        = "${var.pod_cidr}"
   }
 }

--- a/resources/calico/calico.yaml
+++ b/resources/calico/calico.yaml
@@ -76,6 +76,8 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
+            - name: IP_AUTODETECTION_METHOD
+              value: "${network_ip_autodetection_method}"
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "network_mtu" {
   default     = "1500"
 }
 
+variable "network_ip_autodetection_method" {
+  description = "Method to autodetect the host IPv4 address (applies to calico only)"
+  type        = "string"
+  default     = "first-found"
+}
+
 variable "pod_cidr" {
   description = "CIDR IP range to assign Kubernetes pods"
   type        = "string"


### PR DESCRIPTION
* Calico's default method "first-found" is appropriate for single-NIC or bonded-NIC bare-metal and for clouds
* On bare-metal machines with multiple NICs, first-found may result in Calico pods picking an unintended IP address (perhaps an admin has dedicated certain NICs to certain purposes). It mat be helpful to use `can-reach=DEST` or `interface=REGEX` to select the host's address
* Caveat: autodetection method is set for the Calico DaemonSet so the choice must be appropriate for all machines in the cluster.
* https://docs.projectcalico.org/v3.1/reference/node/configuration#ip-autodetection-methods

Original issue: https://github.com/poseidon/typhoon/issues/124