### PR TITLE
Switch apiserver certificate to system:masters org

### DIFF
--- a/conditional.tf
+++ b/conditional.tf
@@ -22,7 +22,8 @@ resource "template_dir" "calico-manifests" {
     calico_image     = "${var.container_images["calico"]}"
     calico_cni_image = "${var.container_images["calico_cni"]}"
 
-    network_mtu = "${var.network_mtu}"
-    pod_cidr    = "${var.pod_cidr}"
+    network_mtu                     = "${var.network_mtu}"
+    network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
+    pod_cidr                        = "${var.pod_cidr}"
   }
 }

--- a/resources/calico/calico.yaml
+++ b/resources/calico/calico.yaml
@@ -76,6 +76,8 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
+            - name: IP_AUTODETECTION_METHOD
+              value: "${network_ip_autodetection_method}"
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -62,7 +62,7 @@ resource "tls_cert_request" "apiserver" {
 
   subject {
     common_name  = "kube-apiserver"
-    organization = "kube-master"
+    organization = "system:masters"
   }
 
   dns_names = [

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "network_mtu" {
   default     = "1500"
 }
 
+variable "network_ip_autodetection_method" {
+  description = "Method to autodetect the host IPv4 address (applies to calico only)"
+  type        = "string"
+  default     = "first-found"
+}
+
 variable "pod_cidr" {
   description = "CIDR IP range to assign Kubernetes pods"
   type        = "string"


### PR DESCRIPTION
* A kubernetes apiserver should be authorized to make requests to kubelets using an admin role associated with system:masters
* Kubelet defaults to AlwaysAllow so an apiserver that presented a valid certificate had all access to the Kubelet. With Webhook authorization, we're making that admin access explicit
* Its important the apiserver be able to perform or proxy to kubelets for kubectl log, exec, port-forward, etc.
* https://github.com/poseidon/typhoon/issues/215