### PR TITLE
Change apiserver port from 443 to 6443

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Find bootkube assets rendered to the `asset_dir` path. That's it.
 Render bootkube assets directly with bootkube v0.12.0.
 
 ```sh
-bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=https://node1.example.com:2379
+bootkube render --asset-dir=assets --api-servers=https://node1.example.com:6443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=https://node1.example.com:2379
 ```
 
 Compare assets. Rendered assets may differ slightly from bootkube assets to reflect decisions made by the [Typhoon](https://github.com/poseidon/typhoon) distribution.

--- a/assets.tf
+++ b/assets.tf
@@ -12,6 +12,7 @@ resource "template_dir" "bootstrap-manifests" {
     service_cidr   = "${var.service_cidr}"
 
     trusted_certs_dir = "${var.trusted_certs_dir}"
+    apiserver_port    = "${var.apiserver_port}"
   }
 }
 
@@ -35,9 +36,10 @@ resource "template_dir" "manifests" {
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
     kube_dns_service_ip   = "${cidrhost(var.service_cidr, 10)}"
     trusted_certs_dir     = "${var.trusted_certs_dir}"
+    apiserver_port        = "${var.apiserver_port}"
 
     ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
-    server             = "${format("https://%s:443", element(var.api_servers, 0))}"
+    server             = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
     apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
     apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
     serviceaccount_pub = "${base64encode(tls_private_key.service-account.public_key_pem)}"
@@ -68,7 +70,7 @@ data "template_file" "kubeconfig" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:443", element(var.api_servers, 0))}"
+    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
   }
 }
 
@@ -80,6 +82,6 @@ data "template_file" "user-kubeconfig" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:443", element(var.api_servers, 0))}"
+    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -65,5 +65,5 @@ output "kubelet_key" {
 }
 
 output "server" {
-  value = "${format("https://%s:443", element(var.api_servers, 0))}"
+  value = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
 }

--- a/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -22,7 +22,7 @@ spec:
     - --etcd-servers=${etcd_servers}
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-    - --secure-port=443
+    - --secure-port=${apiserver_port}
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
     - --service-cluster-ip-range=${service_cidr}
     - --cloud-provider=${cloud_provider}
@@ -41,9 +41,6 @@ spec:
     - mountPath: /etc/kubernetes/secrets
       name: secrets
       readOnly: true
-    - mountPath: /var/lock
-      name: var-lock
-      readOnly: false
   hostNetwork: true
   volumes:
   - name: secrets
@@ -52,6 +49,3 @@ spec:
   - name: ssl-certs-host
     hostPath:
       path: ${trusted_certs_dir}
-  - name: var-lock
-    hostPath:
-      path: /var/lock

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -39,7 +39,7 @@ spec:
         - --etcd-servers=${etcd_servers}
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-        - --secure-port=443
+        - --secure-port=${apiserver_port}
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --service-cluster-ip-range=${service_cidr}
         - --storage-backend=etcd3
@@ -57,9 +57,6 @@ spec:
         - mountPath: /etc/kubernetes/secrets
           name: secrets
           readOnly: true
-        - mountPath: /var/lock
-          name: var-lock
-          readOnly: false
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -74,9 +71,6 @@ spec:
       - name: secrets
         secret:
           secretName: kube-apiserver
-      - name: var-lock
-        hostPath:
-          path: /var/lock
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,11 @@ variable "ca_private_key" {
   type        = "string"
   default     = ""
 }
+
+# unofficial, temporary, may be removed without notice
+
+variable "apiserver_port" {
+  description = "kube-apiserver port"
+  type        = "string"
+  default     = "6443"
+}


### PR DESCRIPTION
* Requires updating load balancers, firewall rules, security groups, and potentially routers/balancers
* Temporarily allow apiserver_port override to accommodate edge cases or migration
* https://github.com/kubernetes-incubator/bootkube/pull/789

Driving motivation here is that it is part of a simplifying and cost-saving improvement to Typhoon clusters. It also aligns with other some upstream conventions, though that alone wouldn't be worth the trouble.