### PR TITLE
Update Kubernetes from v1.10.5 to v1.11.x

### DIFF
--- a/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -20,6 +20,7 @@ spec:
     - --etcd-certfile=/etc/kubernetes/secrets/etcd-client.crt
     - --etcd-keyfile=/etc/kubernetes/secrets/etcd-client.key
     - --etcd-servers=${etcd_servers}
+    - --insecure-port=0
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
     - --secure-port=${apiserver_port}

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -37,6 +37,7 @@ spec:
         - --etcd-certfile=/etc/kubernetes/secrets/etcd-client.crt
         - --etcd-keyfile=/etc/kubernetes/secrets/etcd-client.key
         - --etcd-servers=${etcd_servers}
+        - --insecure-port=0
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
         - --secure-port=${apiserver_port}

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "container_images" {
     calico_cni       = "quay.io/calico/cni:v3.1.3"
     flannel          = "quay.io/coreos/flannel:v0.10.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
-    hyperkube        = "k8s.gcr.io/hyperkube:v1.10.5"
+    hyperkube        = "k8s.gcr.io/hyperkube:v1.11.0"
     kubedns          = "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10"
     kubedns_dnsmasq  = "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10"
     kubedns_sidecar  = "k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10"


### PR DESCRIPTION
* Update hyperkube from v1.10.5 to v1.11.0
* Explicitly disable apiserver 127.0.0.1 insecure port
    * Although the --insecure-port flag is deprecated, kube-apiserver defaults to listening on 127.0.0.1:8080
    * Explicitly disable insecure localhost listener, we don't use it
    * kubernetes/kubernetes#59018 (comment)
    * 5f3546b