### PR TITLE
Update Calico from v3.1.3 to v3.2.0

### DIFF
--- a/resources/calico/bgpconfigurations-crd.yaml
+++ b/resources/calico/bgpconfigurations-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico BGP Configuration
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org

--- a/resources/calico/bgppeers-crd.yaml
+++ b/resources/calico/bgppeers-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico BGP Peers
 kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org

--- a/resources/calico/calico.yaml
+++ b/resources/calico/calico.yaml
@@ -32,35 +32,8 @@ spec:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
-            # Enable felix info logging.
-            - name: FELIX_LOGSEVERITYSCREEN
-              value: "info"
-            # Cluster type to identify the deployment type
-            - name: CLUSTER_TYPE
-              value: "k8s,bgp"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "true"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "ACCEPT"
-            # Disable IPV6 on Kubernetes.
-            - name: FELIX_IPV6SUPPORT
-              value: "false"
-            # Set MTU for tunnel device used if ipip is enabled
-            - name: FELIX_IPINIPMTU
-              value: "${network_mtu}"
-            # Wait for the datastore.
+            # Wait for datastore
             - name: WAIT_FOR_DATASTORE
-              value: "true"
-            # The Calico IPv4 pool CIDR (should match `--cluster-cidr`).
-            - name: CALICO_IPV4POOL_CIDR
-              value: "${pod_cidr}"
-            # Enable IPIP
-            - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
-            # Enable IP-in-IP within Felix.
-            - name: FELIX_IPINIPENABLED
               value: "true"
             # Typha support: controlled by the ConfigMap.
             - name: FELIX_TYPHAK8SSERVICENAME
@@ -73,11 +46,47 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Calico network backend
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
               value: "${network_ip_autodetection_method}"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            # Enable IP-in-IP within Felix.
+            - name: FELIX_IPINIPENABLED
+              value: "true"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # The Calico IPv4 pool CIDR (should match `--cluster-cidr`).
+            - name: CALICO_IPV4POOL_CIDR
+              value: "${pod_cidr}"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Enable felix info logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:
@@ -89,13 +98,16 @@ spec:
             httpGet:
               path: /liveness
               port: 9099
+              host: localhost
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
           readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9099
+            exec:
+              command:
+                - /bin/calico-node
+                - -bird-ready
+                - -felix-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
@@ -115,19 +127,24 @@ spec:
             # Name of the CNI config file to create on each node.
             - name: CNI_CONF_NAME
               value: "10-calico.conflist"
+            # Set node name based on k8s nodeName
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             # Contents of the CNI config to create on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: cni_network_config
-            # Set node name based on k8s nodeName
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: CNI_NET_DIR
               value: "/etc/kubernetes/cni/net.d"
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir

--- a/resources/calico/cluster-role.yaml
+++ b/resources/calico/cluster-role.yaml
@@ -6,6 +6,7 @@ rules:
   - apiGroups: [""]
     resources:
       - namespaces
+      - serviceaccounts
     verbs:
       - get
       - list

--- a/resources/calico/clusterinformations-crd.yaml
+++ b/resources/calico/clusterinformations-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Cluster Information
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org

--- a/resources/calico/config.yaml
+++ b/resources/calico/config.yaml
@@ -6,6 +6,10 @@ metadata:
 data:
   # Disable Typha for now.
   typha_service_name: "none"
+  # Calico backend to use
+  calico_backend: "bird"
+  # Calico MTU
+  veth_mtu: "${network_mtu}"
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
@@ -17,7 +21,7 @@ data:
           "log_level": "info",
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
-          "mtu": ${network_mtu},
+          "mtu": __CNI_MTU__,
           "ipam": {
             "type": "host-local",
             "subnet": "usePodCidr"

--- a/resources/calico/felixconfigurations-crd.yaml
+++ b/resources/calico/felixconfigurations-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
    name: felixconfigurations.crd.projectcalico.org

--- a/resources/calico/globalnetworkpolicies-crd.yaml
+++ b/resources/calico/globalnetworkpolicies-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org

--- a/resources/calico/globalnetworksets-crd.yaml
+++ b/resources/calico/globalnetworksets-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Sets
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org

--- a/resources/calico/hostendpoints-crd.yaml
+++ b/resources/calico/hostendpoints-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico HostEndpoints
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org

--- a/resources/calico/ippools-crd.yaml
+++ b/resources/calico/ippools-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico IP Pools
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org

--- a/resources/calico/networkpolicies-crd.yaml
+++ b/resources/calico/networkpolicies-crd.yaml
@@ -1,5 +1,4 @@
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Network Policies
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org

--- a/variables.tf
+++ b/variables.tf
@@ -69,8 +69,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.1.3"
-    calico_cni       = "quay.io/calico/cni:v3.1.3"
+    calico           = "quay.io/calico/node:v3.2.1"
+    calico_cni       = "quay.io/calico/cni:v3.2.1"
     flannel          = "quay.io/coreos/flannel:v0.10.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     hyperkube        = "k8s.gcr.io/hyperkube:v1.11.2"


### PR DESCRIPTION
* Most upstream changes were buried in calico#1884 which switched from non-templated manifests to templating
* https://github.com/projectcalico/calico/pull/1884
* https://github.com/projectcalico/calico/pull/1853
* https://github.com/projectcalico/calico/pull/2069
* https://github.com/projectcalico/calico/pull/2032
* https://github.com/projectcalico/calico/pull/1841
* https://github.com/projectcalico/calico/pull/1770