### PR TITLE
Update Kubernetes from v1.11.3 to v1.12.x

### DIFF
--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -59,6 +59,8 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 15
         volumeMounts:
+        - name: var-run-kubernetes
+          mountPath: /var/run/kubernetes
         - name: secrets
           mountPath: /etc/kubernetes/secrets
           readOnly: true
@@ -79,6 +81,8 @@ spec:
         operator: Exists
         effect: NoSchedule
       volumes:
+      - name: var-run-kubernetes
+        emptyDir: {}
       - name: secrets
         secret:
           secretName: kube-controller-manager

--- a/variables.tf
+++ b/variables.tf
@@ -73,9 +73,9 @@ variable "container_images" {
     calico_cni       = "quay.io/calico/cni:v3.2.3"
     flannel          = "quay.io/coreos/flannel:v0.10.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
-    hyperkube        = "k8s.gcr.io/hyperkube:v1.11.3"
+    hyperkube        = "k8s.gcr.io/hyperkube:v1.12.1"
     coredns          = "k8s.gcr.io/coredns:1.2.2"
-    pod_checkpointer = "quay.io/coreos/pod-checkpointer:9dc83e1ab3bc36ca25c9f7c18ddef1b91d4a0558"
+    pod_checkpointer = "quay.io/coreos/pod-checkpointer:018007e77ccd61e8e59b7e15d7fc5e318a5a2682"
   }
 }
 


### PR DESCRIPTION
* Update hyperkube image from v1.11.3 to v1.12.1
* Mount an empty dir for the controller-manager to work around https://github.com/kubernetes/kubernetes/issues/68973
 * Update coreos/pod-checkpointer to strip affinity from checkpointed pod manifests. Kubernetes v1.12.0-rc.1 introduced a default affinity that appears on checkpointed manifests; but it prevented scheduling and checkpointed pods should not have an affinity, they're run directly by the Kubelet on the local node
    * https://github.com/kubernetes-incubator/bootkube/issues/1001
    * https://github.com/kubernetes/kubernetes/pull/68173