### PR TITLE
Raise CoreDNS replica count to at least 2

### DIFF
--- a/resources/manifests/coredns/deployment.yaml
+++ b/resources/manifests/coredns/deployment.yaml
@@ -8,24 +8,39 @@ metadata:
     kubernetes.io/name: "CoreDNS"
     kubernetes.io/cluster-service: "true"
 spec:
-  # replicas: not specified here:
-  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-  # 2. Default is 1.
-  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  replicas: ${control_plane_replicas}
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
   selector:
     matchLabels:
+      tier: control-plane
       k8s-app: coredns
   template:
     metadata:
       labels:
+        tier: control-plane
         k8s-app: coredns
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: tier
+                  operator: In
+                  values:
+                  - control-plane
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - codedns
+              topologyKey: kubernetes.io/hostname
       serviceAccountName: coredns
       tolerations:
         - key: node-role.kubernetes.io/master


### PR DESCRIPTION
* Run at least two replicas of CoreDNS to better support rolling updates (previously, kube-dns had a pod nanny)
* On multi-master clusters, set the CoreDNS replica count to match the number of masters (e.g. a 3-master cluster previously used replicas:1, now replicas:3)
* Add AntiAffinity preferred rule to favor distributing CoreDNS pods across nodes

Closes #80 