### PR TITLE
Add docker/default seccomp profile to control plane pods

### DIFF
--- a/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: bootstrap-kube-apiserver
   namespace: kube-system
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   containers:
   - name: kube-apiserver

--- a/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: bootstrap-kube-controller-manager
   namespace: kube-system
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   containers:
   - name: kube-controller-manager

--- a/resources/bootstrap-manifests/bootstrap-scheduler.yaml
+++ b/resources/bootstrap-manifests/bootstrap-scheduler.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: bootstrap-kube-scheduler
   namespace: kube-system
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
 spec:
   containers:
   - name: kube-scheduler

--- a/resources/calico/calico.yaml
+++ b/resources/calico/calico.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
       serviceAccountName: calico-node

--- a/resources/flannel/flannel.yaml
+++ b/resources/flannel/flannel.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         tier: node
         k8s-app: flannel
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: flannel
       containers:

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -18,6 +18,7 @@ spec:
         k8s-app: kube-apiserver
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       containers:
       - name: kube-apiserver

--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         tier: control-plane
         k8s-app: kube-controller-manager
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       affinity:
         podAntiAffinity:

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         tier: node
         k8s-app: kube-proxy
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       containers:
       - name: kube-proxy

--- a/resources/manifests/kube-scheduler.yaml
+++ b/resources/manifests/kube-scheduler.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         tier: control-plane
         k8s-app: kube-scheduler
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       affinity:
         podAntiAffinity:

--- a/resources/manifests/pod-checkpointer.yaml
+++ b/resources/manifests/pod-checkpointer.yaml
@@ -18,6 +18,7 @@ spec:
         k8s-app: pod-checkpointer
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       containers:
       - name: pod-checkpointer


### PR DESCRIPTION
* By default, Kubernetes starts containers without the Docker runtime's default seccomp profile (e.g. seccomp=unconfined)
* https://docs.docker.com/engine/security/seccomp/#pass-a-profile-for-a-container