### PR TITLE
Switch kube-proxy from iptables mode to ipvs mode

### DIFF
--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -28,7 +28,7 @@ spec:
         - --cluster-cidr=${pod_cidr}
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --proxy-mode=iptables
+        - --proxy-mode=ipvs
         env:
           - name: NODE_NAME
             valueFrom:


### PR DESCRIPTION
* kube-proxy ipvs was marked stable in Kubernetes v1.11, Calico autodetects ipvs appropriately, and I think ipvs is ready for prime time