### PR TITLE
Update CoreDNS to v1.2.4 and Kubernetes to v1.12.2

### DIFF
--- a/resources/manifests/coredns/cluster-role.yaml
+++ b/resources/manifests/coredns/cluster-role.yaml
@@ -14,3 +14,8 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "container_images" {
     flannel          = "quay.io/coreos/flannel:v0.10.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     hyperkube        = "k8s.gcr.io/hyperkube:v1.12.1"
-    coredns          = "k8s.gcr.io/coredns:1.2.2"
+    coredns          = "k8s.gcr.io/coredns:1.2.4"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:018007e77ccd61e8e59b7e15d7fc5e318a5a2682"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,7 +73,7 @@ variable "container_images" {
     calico_cni       = "quay.io/calico/cni:v3.3.0"
     flannel          = "quay.io/coreos/flannel:v0.10.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
-    hyperkube        = "k8s.gcr.io/hyperkube:v1.12.1"
+    hyperkube        = "k8s.gcr.io/hyperkube:v1.12.2"
     coredns          = "k8s.gcr.io/coredns:1.2.4"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:018007e77ccd61e8e59b7e15d7fc5e318a5a2682"
   }


### PR DESCRIPTION
Hyperkube v1.12.2:
* https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md/#v1122

CoreDNS v1.2.4:
* https://coredns.io/2018/10/17/coredns-1.2.4-release/
* https://coredns.io/2018/10/16/coredns-1.2.3-release/