### PR TITLE
Disable Calico usage reporting by default

### DIFF
--- a/conditional.tf
+++ b/conditional.tf
@@ -25,5 +25,6 @@ resource "template_dir" "calico-manifests" {
     network_mtu                     = "${var.network_mtu}"
     network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
     pod_cidr                        = "${var.pod_cidr}"
+    enable_reporting                = "${var.enable_reporting}"
   }
 }

--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -43,6 +43,8 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: typha_service_name
+            - name: FELIX_USAGEREPORTINGENABLED
+              value: "${enable_reporting}"
             # Set node name based on k8s nodeName.
             - name: NODENAME
               valueFrom:

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,12 @@ variable "container_images" {
   }
 }
 
+variable "enable_reporting" {
+  type = "string"
+  description = "Enable usage or analytics reporting to upstream component owners (Tigera: Calico)"
+  default = "false"
+}
+
 variable "trusted_certs_dir" {
   description = "Path to the directory on cluster nodes where trust TLS certs are kept"
   type        = "string"


### PR DESCRIPTION
* Calico Felix has been reporting anonymous usage data about Calico version and cluster size
* https://docs.projectcalico.org/v3.3/reference/felix/configuration
* Add an `enable_reporting` variable and default to false