### PR TITLE
Update pod-checkpointer image to query Kubelet secure api

### DIFF
--- a/resources/manifests/pod-checkpointer-cluster-role-binding.yaml
+++ b/resources/manifests/pod-checkpointer-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-checkpointer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-checkpointer
+subjects:
+- kind: ServiceAccount
+  name: pod-checkpointer
+  namespace: kube-system

--- a/resources/manifests/pod-checkpointer-cluster-role.yaml
+++ b/resources/manifests/pod-checkpointer-cluster-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-checkpointer
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+    verbs:
+      - get

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "container_images" {
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     hyperkube        = "k8s.gcr.io/hyperkube:v1.12.2"
     coredns          = "k8s.gcr.io/coredns:1.2.6"
-    pod_checkpointer = "quay.io/coreos/pod-checkpointer:018007e77ccd61e8e59b7e15d7fc5e318a5a2682"
+    pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }
 }
 


### PR DESCRIPTION
* Updates pod-checkpointer to prefer the Kubelet secure API (before falling back to the Kubelet read-only API that is disabled on Typhoon clusters since https://github.com/poseidon/typhoon/pull/324)
* Previously, pod-checkpointer checkpointed an initial set of pods during bootstrapping so recovery from power cycling clusters was unaffected, but logs were noisy (https://github.com/poseidon/typhoon/pull/324#issuecomment-440967539)
* https://github.com/kubernetes-incubator/bootkube/pull/1027

Related:

* https://github.com/kubernetes-incubator/bootkube/pull/1025