### PR TITLE
Update hyperkube from v1.12.3 to v1.13.0

### DIFF
--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -59,8 +59,6 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 15
         volumeMounts:
-        - name: var-run-kubernetes
-          mountPath: /var/run/kubernetes
         - name: secrets
           mountPath: /etc/kubernetes/secrets
           readOnly: true
@@ -81,8 +79,6 @@ spec:
         operator: Exists
         effect: NoSchedule
       volumes:
-      - name: var-run-kubernetes
-        emptyDir: {}
       - name: secrets
         secret:
           secretName: kube-controller-manager

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "container_images" {
     flannel          = "quay.io/coreos/flannel:v0.10.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.2.3"
-    hyperkube        = "k8s.gcr.io/hyperkube:v1.12.3"
+    hyperkube        = "k8s.gcr.io/hyperkube:v1.13.0"
     coredns          = "k8s.gcr.io/coredns:1.2.6"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }


### PR DESCRIPTION
Update hyperkube from v1.12.3 to v1.13.0.

Validated:

- [x] v1.13.0-beta.1
- [x] v1.13.0-rc.2
- [x] v1.13.0