### PR TITLE
Make --nodeport-addresses configurable

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -36,6 +36,7 @@ resource "template_dir" "manifests" {
     cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
     trusted_certs_dir      = "${var.trusted_certs_dir}"
     apiserver_port         = "${var.apiserver_port}"
+    nodeport_addresses     = "${var.nodeport_addresses}"
 
     ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     server             = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -29,6 +29,7 @@ spec:
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --proxy-mode=iptables
+        - --nodeport-addresses=${nodeport_addresses}
         env:
           - name: NODE_NAME
             valueFrom:

--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,12 @@ variable "ca_private_key" {
   default     = ""
 }
 
+variable "nodeport_addresses" {
+  description = "IP range(s) where kube-proxy is allowed to proxy nodeport services to"
+  type        = "string"
+  default     = "[]"
+}
+
 # unofficial, temporary, may be removed without notice
 
 variable "apiserver_port" {


### PR DESCRIPTION
This change allows the `--nodeport-addresses` option of `kube-proxy` to be configurable inside the Terraform configuration

Feedback and suggestions welcome!