### PR TITLE
Enable certificates.k8s.io API certificate issuance

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -38,6 +38,7 @@ resource "template_dir" "manifests" {
     apiserver_port         = "${var.apiserver_port}"
 
     ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
+    ca_key            = "${base64encode(var.ca_private_key == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key)}"
     server             = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
     apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
     apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"

--- a/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -16,6 +16,8 @@ spec:
     - --cluster-cidr=${pod_cidr}
     - --service-cluster-ip-range=${service_cidr}
     - --cloud-provider=${cloud_provider}
+    - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
+    - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
     - --configure-cloud-routes=false
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --leader-elect=true

--- a/resources/manifests/kube-controller-manager-secret.yaml
+++ b/resources/manifests/kube-controller-manager-secret.yaml
@@ -7,3 +7,5 @@ type: Opaque
 data:
   service-account.key: ${serviceaccount_key}
   ca.crt: ${ca_cert}
+  ca.key: ${ca_key}
+

--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -47,6 +47,8 @@ spec:
         - --cloud-provider=${cloud_provider}
         - --cluster-cidr=${pod_cidr}
         - --service-cluster-ip-range=${service_cidr}
+        - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
+        - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
         - --configure-cloud-routes=false
         - --leader-elect=true
         - --flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins


### PR DESCRIPTION
* Allow kube-controller-manager to sign Approved CSR's using the cluster CA private key to issue cluster certificates
* System components that need to use certificates signed by the cluster CA can submit a CSR to the apiserver, have an admin inspect and manually approve it, and be issued a certificate
* Admins should inspect CSRs very carefully to ensure their origin and authorization level are appropriate
* https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/#approving-certificate-signing-requests