### PR TITLE
Remove support for bring-your-own certificate authority

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -37,8 +37,8 @@ resource "template_dir" "manifests" {
     trusted_certs_dir      = "${var.trusted_certs_dir}"
     apiserver_port         = "${var.apiserver_port}"
 
-    ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
-    ca_key             = "${base64encode(var.ca_private_key == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key)}"
+    ca_cert            = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
+    ca_key             = "${base64encode(tls_private_key.kube-ca.private_key_pem)}"
     server             = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
     apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
     apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
@@ -90,7 +90,7 @@ data "template_file" "kubeconfig-kubelet" {
   template = "${file("${path.module}/resources/kubeconfig-kubelet")}"
 
   vars {
-    ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
+    ca_cert      = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
     server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
@@ -102,7 +102,7 @@ data "template_file" "kubeconfig-admin" {
 
   vars {
     name         = "${var.cluster_name}"
-    ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
+    ca_cert      = "${base64encode(tls_self_signed_cert.kube-ca.*.cert_pem)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.admin.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.admin.private_key_pem)}"
     server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -65,7 +65,7 @@ output "etcd_peer_key" {
 # contents so the raw components of the kubeconfig may be needed.
 
 output "ca_cert" {
-  value = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
+  value = "${base64encode(tls_self_signed_cert.kube-ca.*.cert_pem)}"
 }
 
 output "kubelet_cert" {

--- a/tls-aggregation.tf
+++ b/tls-aggregation.tf
@@ -1,3 +1,12 @@
+# NOTE: Across this module, the following workaround is used:
+# `"${var.some_var == "condition" ? join(" ", tls_private_key.aggregation-ca.*.private_key_pem) : ""}"`
+# Due to https://github.com/hashicorp/hil/issues/50, both sides of conditions
+# are evaluated, until one of them is discarded. When a `count` is used resources
+# can be referenced as lists with the `.*` notation, and arrays are allowed to be
+# empty. The `join()` interpolation function is then used to cast them back to
+# a string. Since `count` can only be 0 or 1, the returned value is either empty
+# (and discarded anyways) or the desired value.
+
 # Kubernetes Aggregation CA (i.e. front-proxy-ca)
 # Files: tls/{aggregation-ca.crt,aggregation-ca.key}
 

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -1,27 +1,11 @@
-# NOTE: Across this module, the following syntax is used at various places:
-#   `"${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"`
-#
-# Due to https://github.com/hashicorp/hil/issues/50, both sides of conditions
-# are evaluated, until one of them is discarded. Unfortunately, the
-# `{tls_private_key/tls_self_signed_cert}.kube-ca` resources are created
-# conditionally and might not be present - in which case an error is
-# generated. Because a `count` is used on these ressources, the resources can be
-# referenced as lists with the `.*` notation, and arrays are allowed to be
-# empty. The `join()` interpolation function is then used to cast them back to
-# a string. Since `count` can only be 0 or 1, the returned value is either empty
-# (and discarded anyways) or the desired value.
-
 # Kubernetes CA (tls/{ca.crt,ca.key})
-resource "tls_private_key" "kube-ca" {
-  count = "${var.ca_certificate == "" ? 1 : 0}"
 
+resource "tls_private_key" "kube-ca" {
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_self_signed_cert" "kube-ca" {
-  count = "${var.ca_certificate == "" ? 1 : 0}"
-
   key_algorithm   = "${tls_private_key.kube-ca.algorithm}"
   private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
 
@@ -41,12 +25,12 @@ resource "tls_self_signed_cert" "kube-ca" {
 }
 
 resource "local_file" "kube-ca-key" {
-  content  = "${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"
+  content  = "${tls_private_key.kube-ca.private_key_pem}"
   filename = "${var.asset_dir}/tls/ca.key"
 }
 
 resource "local_file" "kube-ca-crt" {
-  content  = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate}"
+  content  = "${tls_self_signed_cert.kube-ca.cert_pem}"
   filename = "${var.asset_dir}/tls/ca.crt"
 }
 
@@ -82,9 +66,9 @@ resource "tls_cert_request" "apiserver" {
 resource "tls_locally_signed_cert" "apiserver" {
   cert_request_pem = "${tls_cert_request.apiserver.cert_request_pem}"
 
-  ca_key_algorithm   = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.ca_key_alg}"
-  ca_private_key_pem = "${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"
-  ca_cert_pem        = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem): var.ca_certificate}"
+  ca_key_algorithm   = "${tls_self_signed_cert.kube-ca.key_algorithm}"
+  ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
+  ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
 
   validity_period_hours = 8760
 
@@ -126,9 +110,9 @@ resource "tls_cert_request" "admin" {
 resource "tls_locally_signed_cert" "admin" {
   cert_request_pem = "${tls_cert_request.admin.cert_request_pem}"
 
-  ca_key_algorithm   = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.ca_key_alg}"
-  ca_private_key_pem = "${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"
-  ca_cert_pem        = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem): var.ca_certificate}"
+  ca_key_algorithm   = "${tls_self_signed_cert.kube-ca.key_algorithm}"
+  ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
+  ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
 
   validity_period_hours = 8760
 
@@ -186,9 +170,9 @@ resource "tls_cert_request" "kubelet" {
 resource "tls_locally_signed_cert" "kubelet" {
   cert_request_pem = "${tls_cert_request.kubelet.cert_request_pem}"
 
-  ca_key_algorithm   = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.ca_key_alg}"
-  ca_private_key_pem = "${var.ca_certificate == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key}"
-  ca_cert_pem        = "${var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate}"
+  ca_key_algorithm   = "${tls_self_signed_cert.kube-ca.key_algorithm}"
+  ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
+  ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
 
   validity_period_hours = 8760
 

--- a/variables.tf
+++ b/variables.tf
@@ -98,24 +98,6 @@ variable "enable_aggregation" {
   default     = "false"
 }
 
-variable "ca_certificate" {
-  description = "Existing PEM-encoded CA certificate (generated if blank)"
-  type        = "string"
-  default     = ""
-}
-
-variable "ca_key_alg" {
-  description = "Algorithm used to generate ca_key (required if ca_cert is specified)"
-  type        = "string"
-  default     = "RSA"
-}
-
-variable "ca_private_key" {
-  description = "Existing Certificate Authority private key (required if ca_certificate is set)"
-  type        = "string"
-  default     = ""
-}
-
 # unofficial, temporary, may be removed without notice
 
 variable "apiserver_port" {


### PR DESCRIPTION
* Remove the `ca_certificate`, `ca_key_alg`, and `ca_private_key` variables
* Typhoon does not plan to expose custom CA support. Continuing to support it clutters the implementation and security auditing
* Using an existing CA certificate and private key has been supported in `terraform-render-bootkube` only to match bootkube

Relevant [discussion](https://github.com/poseidon/typhoon/issues/108) where Typhoon won't allow bring-your-own CA. Leaving this open for a while.