### PR TITLE
Re-enable kube-scheduler and kube-controller-manager HTTP ports

### DIFF
--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -51,7 +51,6 @@ spec:
         - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
         - --configure-cloud-routes=false
         - --leader-elect=true
-        - --port=0
         - --flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key

--- a/resources/manifests/kube-scheduler.yaml
+++ b/resources/manifests/kube-scheduler.yaml
@@ -53,7 +53,6 @@ spec:
         - ./hyperkube
         - scheduler
         - --leader-elect=true
-        - --port=0
         livenessProbe:
           httpGet:
             scheme: HTTPS


### PR DESCRIPTION
* Allow Prometheus to scrape metrics from kube-scheduler and kube-controller-manager

Partially reverts #105