### PR TITLE
Update CoreDNS from v1.3.0 to v1.3.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "container_images" {
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.2.4"
     hyperkube        = "k8s.gcr.io/hyperkube:v1.13.2"
-    coredns          = "k8s.gcr.io/coredns:1.3.0"
+    coredns          = "k8s.gcr.io/coredns:1.3.1"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }
 }


### PR DESCRIPTION
* https://coredns.io/2019/01/13/coredns-1.3.1-release/