### PR TITLE
Assign Pod Priority Classes to control plane components

### DIFF
--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
+      priorityClassName: system-node-critical
       serviceAccountName: calico-node
       tolerations:
         - effect: NoSchedule

--- a/resources/flannel/daemonset.yaml
+++ b/resources/flannel/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
+      priorityClassName: system-node-critical
       serviceAccountName: flannel
       tolerations:
         - effect: NoSchedule

--- a/resources/kube-router/daemonset.yaml
+++ b/resources/kube-router/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
+      priorityClassName: system-node-critical
       serviceAccountName: kube-router
       tolerations:
         - effect: NoSchedule

--- a/resources/manifests/coredns/deployment.yaml
+++ b/resources/manifests/coredns/deployment.yaml
@@ -41,6 +41,7 @@ spec:
                   values:
                   - coredns
               topologyKey: kubernetes.io/hostname
+      priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -48,7 +49,6 @@ spec:
       containers:
         - name: coredns
           image: ${coredns_image}
-          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 170Mi

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -27,6 +27,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
       serviceAccountName: kube-apiserver
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -36,6 +36,17 @@ spec:
                   values:
                   - kube-controller-manager
               topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: kube-controller-manager
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       containers:
       - name: kube-controller-manager
         image: ${hyperkube_image}
@@ -72,16 +83,6 @@ spec:
         - name: ssl-host
           mountPath: /etc/ssl/certs
           readOnly: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-      serviceAccountName: kube-controller-manager
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
       volumes:
       - name: secrets
         secret:

--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -24,6 +24,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
+      priorityClassName: system-node-critical
       serviceAccountName: kube-proxy
       tolerations:
       - effect: NoSchedule

--- a/resources/manifests/kube-scheduler.yaml
+++ b/resources/manifests/kube-scheduler.yaml
@@ -38,6 +38,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/resources/manifests/pod-checkpointer.yaml
+++ b/resources/manifests/pod-checkpointer.yaml
@@ -25,9 +25,10 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       hostNetwork: true
-      serviceAccountName: pod-checkpointer
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: system-node-critical
+      serviceAccountName: pod-checkpointer
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
@@ -52,7 +53,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        imagePullPolicy: Always
         volumeMounts:
         - name: kubeconfig
           mountPath: /etc/checkpointer


### PR DESCRIPTION
* Priority Admission Controller has been enabled since Typhoon v1.11.1
* Assign cluster and node components a builtin priorityClassName (higher is higher priority) to inform scheduler prepemption, scheduling order, and node out-of-resource eviction order