### PR TITLE
Use "stock" coredns manifests

### DIFF
--- a/resources/manifests/coredns/cluster-role-binding.yaml
+++ b/resources/manifests/coredns/cluster-role-binding.yaml
@@ -1,11 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:coredns
-  labels:
-    kubernetes.io/bootstrapping: rbac-defaults
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: system:coredns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/resources/manifests/coredns/cluster-role.yaml
+++ b/resources/manifests/coredns/cluster-role.yaml
@@ -1,11 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:coredns
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: system:coredns
 rules:
-  - apiGroups: [""]
+  - apiGroups:
+    - ""
     resources:
       - endpoints
       - services
@@ -14,8 +16,3 @@ rules:
     verbs:
       - list
       - watch
-  - apiGroups: [""]
-    resources:
-      - nodes
-    verbs:
-      - get

--- a/resources/manifests/coredns/config.yaml
+++ b/resources/manifests/coredns/config.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: coredns
   namespace: kube-system
+  labels:
+      addonmanager.kubernetes.io/mode: EnsureExists
 data:
   Corefile: |
     .:53 {
@@ -11,7 +13,7 @@ data:
         log . {
             class error
         }
-        kubernetes ${cluster_domain_suffix} ${service_cidr} {
+        kubernetes ${cluster_domain_suffix} in-addr.arpa ip6.arpa {
             pods insecure
             upstream
             fallthrough in-addr.arpa ip6.arpa

--- a/resources/manifests/coredns/deployment.yaml
+++ b/resources/manifests/coredns/deployment.yaml
@@ -1,54 +1,42 @@
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: coredns
   namespace: kube-system
   labels:
-    k8s-app: coredns
-    kubernetes.io/name: "CoreDNS"
+    k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "CoreDNS"
 spec:
-  replicas: ${control_plane_replicas}
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
   selector:
     matchLabels:
-      tier: control-plane
-      k8s-app: coredns
+      k8s-app: kube-dns
   template:
     metadata:
       labels:
-        tier: control-plane
-        k8s-app: coredns
+        k8s-app: kube-dns
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: tier
-                  operator: In
-                  values:
-                  - control-plane
-                - key: k8s-app
-                  operator: In
-                  values:
-                  - coredns
-              topologyKey: kubernetes.io/hostname
-      priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
       containers:
         - name: coredns
           image: ${coredns_image}
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 170Mi
@@ -57,19 +45,19 @@ spec:
               memory: 70Mi
           args: [ "-conf", "/etc/coredns/Corefile" ]
           volumeMounts:
-            - name: config
-              mountPath: /etc/coredns
-              readOnly: true
+          - name: config-volume
+            mountPath: /etc/coredns
+            readOnly: true
           ports:
-            - name: dns
-              protocol: UDP
-              containerPort: 53
-            - name: dns-tcp
-              protocol: TCP
-              containerPort: 53
-            - name: metrics
-              protocol: TCP
-              containerPort: 9153
+          - containerPort: 53
+            name: dns
+            protocol: UDP
+          - containerPort: 53
+            name: dns-tcp
+            protocol: TCP
+          - containerPort: 9153
+            name: metrics
+            protocol: TCP
           livenessProbe:
             httpGet:
               path: /health
@@ -94,7 +82,7 @@ spec:
             readOnlyRootFilesystem: true
       dnsPolicy: Default
       volumes:
-        - name: config
+        - name: config-volume
           configMap:
             name: coredns
             items:

--- a/resources/manifests/coredns/service-account.yaml
+++ b/resources/manifests/coredns/service-account.yaml
@@ -4,4 +4,5 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
+      kubernetes.io/cluster-service: "true"
+      addonmanager.kubernetes.io/mode: Reconcile

--- a/resources/manifests/coredns/service.yaml
+++ b/resources/manifests/coredns/service.yaml
@@ -1,23 +1,24 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: coredns
+  name: kube-dns
   namespace: kube-system
   annotations:
-    prometheus.io/scrape: "true"
     prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
   labels:
-    k8s-app: coredns
+    k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "CoreDNS"
 spec:
   selector:
-    k8s-app: coredns
+    k8s-app: kube-dns
   clusterIP: ${cluster_dns_service_ip}
   ports:
-    - name: dns
-      port: 53
-      protocol: UDP
-    - name: dns-tcp
-      port: 53
-      protocol: TCP
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP


### PR DESCRIPTION
This is needed by some CNI plugins like cilium that need to access the DNS service with the kube-dns name.
Also enable reverse lookup in kubernetes block: https://docs.cilium.io/en/v1.4/gettingstarted/k8s-install-etcd-operator/#for-coredns-enable-reverse-lookups