### PR TITLE
Resolve in-addr.arpa and ip6.arpa zones with CoreDNS kubernetes plugin

### DIFF
--- a/resources/manifests/coredns/config.yaml
+++ b/resources/manifests/coredns/config.yaml
@@ -11,7 +11,7 @@ data:
         log . {
             class error
         }
-        kubernetes ${cluster_domain_suffix} ${service_cidr} {
+        kubernetes ${cluster_domain_suffix} in-addr.arpa ip6.arpa {
             pods insecure
             upstream
             fallthrough in-addr.arpa ip6.arpa


### PR DESCRIPTION
* Resolve in-addr.arpa and ip6.arpa DNS PTR requests for Kubernetes service IPs and pod IPs
* Previously, CoreDNS was configured to resolve in-addr.arpa PTR records for service IPs (but not pod IPs)

Before:

```
$ dig 1.0.3.10.in-addr.arpa PTR
...
1.0.3.10.in-addr.arpa.  5       IN      PTR     kubernetes.default.svc.cluster.local.
$ 8.1.2.10.in-addr.arpa PTR
8.1.2.10.in-addr.arpa.  30      IN      PTR     ip-10-2-1-8.CLOUD_SPECIFIC_UPSTREAM
```

After:

```
$ dig 1.0.3.10.in-addr.arpa PTR
...
1.0.3.10.in-addr.arpa.  5       IN      PTR     kubernetes.default.svc.cluster.local.
$ 8.1.2.10.in-addr.arpa PTR
8.1.2.10.in-addr.arpa.  30      IN      PTR     10-2-1-8.prometheus.monitoring.svc.cluster.local.
```