### PR TITLE
Upgrade Calico from v3.5.2 to v3.6.0

### DIFF
--- a/resources/calico/blockaffinities-crd.yaml
+++ b/resources/calico/blockaffinities-crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: felixconfigurations.crd.projectcalico.org
+  name: blockaffinities.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: FelixConfiguration
-    plural: felixconfigurations
-    singular: felixconfiguration
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity

--- a/resources/calico/cluster-role.yaml
+++ b/resources/calico/cluster-role.yaml
@@ -64,6 +64,7 @@ rules:
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
+      - ipamblocks
       - globalnetworkpolicies
       - globalnetworksets
       - networkpolicies
@@ -81,4 +82,25 @@ rules:
     verbs:
       - create
       - update
-
+  # Calico may perform IPAM allocations (not yet used)
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ipamconfigs
+    verbs:
+      - get
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch

--- a/resources/calico/config.yaml
+++ b/resources/calico/config.yaml
@@ -23,8 +23,7 @@ data:
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,
           "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
+            "type": "calico-ipam"
           },
           "policy": {
             "type": "k8s"

--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -99,9 +99,6 @@ spec:
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
               value: "${network_ip_autodetection_method}"
-            # Enable IPIP
-            - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
             # Enable IP-in-IP within Felix.
             - name: FELIX_IPINIPENABLED
               value: "true"
@@ -111,9 +108,8 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: veth_mtu
-            # The Calico IPv4 pool CIDR (should match `--cluster-cidr`).
-            - name: CALICO_IPV4POOL_CIDR
-              value: "${pod_cidr}"
+            - name: NO_DEFAULT_POOLS
+              value: "true"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/resources/calico/default-ipv4-ippool.yaml
+++ b/resources/calico/default-ipv4-ippool.yaml
@@ -1,0 +1,10 @@
+apiVersion: crd.projectcalico.org/v1
+kind: IPPool
+metadata:
+  name: default-ipv4-ippool
+spec:
+  blockSize: 24
+  cidr: ${pod_cidr}
+  ipipMode: Always
+  natOutgoing: true
+  nodeSelector: all()

--- a/resources/calico/ipamblocks.crd.yaml
+++ b/resources/calico/ipamblocks.crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: felixconfigurations.crd.projectcalico.org
+  name: ipamblocks.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: FelixConfiguration
-    plural: felixconfigurations
-    singular: felixconfiguration
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock

--- a/resources/calico/ipamconfigs-crd.yaml
+++ b/resources/calico/ipamconfigs-crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: felixconfigurations.crd.projectcalico.org
+  name: ipamconfigs.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: FelixConfiguration
-    plural: felixconfigurations
-    singular: felixconfiguration
+    kind: IPAMConfig
+    plural: ipamconfigs
+    singular: ipamconfig

--- a/resources/calico/ipamhandles-crd.yaml
+++ b/resources/calico/ipamhandles-crd.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: felixconfigurations.crd.projectcalico.org
+  name: ipamhandles.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: FelixConfiguration
-    plural: felixconfigurations
-    singular: felixconfiguration
+    kind: IPAMHandle
+    plural: ipamhandles
+    singular: ipamhandle

--- a/variables.tf
+++ b/variables.tf
@@ -69,8 +69,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.5.2"
-    calico_cni       = "quay.io/calico/cni:v3.5.2"
+    calico           = "quay.io/calico/node:v3.6.0"
+    calico_cni       = "quay.io/calico/cni:v3.6.0"
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.2.5"


### PR DESCRIPTION
* Add calico-ipam CRDs and RBAC permissions
* Switch IPAM from host-local to calico-ipam!
  * `calico-ipam` subnets `ippools` (defaults to pod CIDR) into `ipamblocks` (defaults to /26, but set to /24 in Typhoon)
  * `host-local` subnets the pod CIDR based on the node PodCIDR field (set via kube-controller-manager as /24's)
* Create a custom default IPv4 IPPool to ensure the block size is kept at /24 to allow 110 pods per node (Kubernetes default)
* Retaining host-local was slightly preferred, but Calico v3.6 is migrating all usage to calico-ipam. The codepath that skipped calico-ipam for KDD was removed
*  https://docs.projectcalico.org/v3.6/release-notes/