### PR TITLE
Reduce calico-node CPU request from 250m to 150m

### DIFF
--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -128,7 +128,7 @@ spec:
             privileged: true
           resources:
             requests:
-              cpu: 250m
+              cpu: 150m
           livenessProbe:
             httpGet:
               path: /liveness


### PR DESCRIPTION
* calico-node uses only a small fraction of its CPU request (i.e. reservation) even under stress. The unbounded limit already allows usage to scale favorably in bursty cases
* Motivation: On instance types that skew memory-optimized (e.g. GCP n1), over-requesting can push the system toward overcommitment (alerts can be tuned). Basically, provide more room for user-applications before reaching overcommitment.
* Overcommitment is not necessarily bad, but 250m seems too generous a minimum given the actual usage