### PR TITLE
Update Kubernetes from v1.13.5 to v1.14.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -69,8 +69,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.6.0"
-    calico_cni       = "quay.io/calico/cni:v3.6.0"
+    calico           = "quay.io/calico/node:v3.6.1"
+    calico_cni       = "quay.io/calico/cni:v3.6.1"
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.2.5"

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "container_images" {
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.2.5"
-    hyperkube        = "k8s.gcr.io/hyperkube:v1.13.5"
+    hyperkube        = "k8s.gcr.io/hyperkube:v1.14.0"
     coredns          = "k8s.gcr.io/coredns:1.3.1"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#v1140

Previously tested:

- [x] v1.14.0-alpha.2
- [x] v1.14.0-beta.0
- [x] v1.14.0-beta.1
- [x] v1.14.0-beta.2
- [x] v1.14.0-rc.1
- [x] v1.14.0