### PR TITLE
Update Calico from v3.6.0 to v3.6.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -69,8 +69,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.6.0"
-    calico_cni       = "quay.io/calico/cni:v3.6.0"
+    calico           = "quay.io/calico/node:v3.6.1"
+    calico_cni       = "quay.io/calico/cni:v3.6.1"
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.2.5"


### PR DESCRIPTION
* https://docs.projectcalico.org/v3.6/release-notes/