### PR TITLE
Add enable_aggregation option (defaults to false)

### DIFF
--- a/resources/manifests/kube-apiserver-secret.yaml
+++ b/resources/manifests/kube-apiserver-secret.yaml
@@ -12,3 +12,7 @@ data:
   etcd-client-ca.crt: ${etcd_ca_cert}
   etcd-client.crt: ${etcd_client_cert}
   etcd-client.key: ${etcd_client_key}
+  aggregation-ca.crt: ${aggregation_ca_cert}
+  aggregation-client.crt: ${aggregation_client_cert}
+  aggregation-client.key: ${aggregation_client_key}
+

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -54,7 +54,7 @@ spec:
         - --insecure-port=0
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname${aggregation_flags}
         - --secure-port=${apiserver_port}
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --service-cluster-ip-range=${service_cidr}

--- a/tls-aggregation.tf
+++ b/tls-aggregation.tf
@@ -1,0 +1,96 @@
+# Kubernetes Aggregation CA (i.e. front-proxy-ca)
+# Files: tls/{aggregation-ca.crt,aggregation-ca.key}
+
+resource "tls_private_key" "aggregation-ca" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "tls_self_signed_cert" "aggregation-ca" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  key_algorithm   = "${tls_private_key.aggregation-ca.algorithm}"
+  private_key_pem = "${tls_private_key.aggregation-ca.private_key_pem}"
+
+  subject {
+    common_name = "kubernetes-front-proxy-ca"
+  }
+
+  is_ca_certificate     = true
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "cert_signing",
+  ]
+}
+
+resource "local_file" "aggregation-ca-key" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  content  = "${tls_private_key.aggregation-ca.private_key_pem}"
+  filename = "${var.asset_dir}/tls/aggregation-ca.key"
+}
+
+resource "local_file" "aggregation-ca-crt" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  content  = "${tls_self_signed_cert.aggregation-ca.cert_pem}"
+  filename = "${var.asset_dir}/tls/aggregation-ca.crt"
+}
+
+# Kubernetes apiserver (i.e. front-proxy-client)
+# Files: tls/{aggregation-client.crt,aggregation-client.key}
+
+resource "tls_private_key" "aggregation-client" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  algorithm = "RSA"
+  rsa_bits  = "2048"
+}
+
+resource "tls_cert_request" "aggregation-client" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  key_algorithm   = "${tls_private_key.aggregation-client.algorithm}"
+  private_key_pem = "${tls_private_key.aggregation-client.private_key_pem}"
+
+  subject {
+    common_name = "kube-apiserver"
+  }
+}
+
+resource "tls_locally_signed_cert" "aggregation-client" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  cert_request_pem = "${tls_cert_request.aggregation-client.cert_request_pem}"
+
+  ca_key_algorithm   = "${tls_self_signed_cert.aggregation-ca.key_algorithm}"
+  ca_private_key_pem = "${tls_private_key.aggregation-ca.private_key_pem}"
+  ca_cert_pem        = "${tls_self_signed_cert.aggregation-ca.cert_pem}"
+
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
+  ]
+}
+
+resource "local_file" "aggregation-client-key" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  content  = "${tls_private_key.aggregation-client.private_key_pem}"
+  filename = "${var.asset_dir}/tls/aggregation-client.key"
+}
+
+resource "local_file" "aggregation-client-crt" {
+  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+
+  content  = "${tls_locally_signed_cert.aggregation-client.cert_pem}"
+  filename = "${var.asset_dir}/tls/aggregation-client.crt"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,12 @@ variable "trusted_certs_dir" {
   default     = "/usr/share/ca-certificates"
 }
 
+variable "enable_aggregation" {
+  description = "Enable the Kubernetes Aggregation Layer (defaults to false, recommended)"
+  type        = "string"
+  default     = "false"
+}
+
 variable "ca_certificate" {
   description = "Existing PEM-encoded CA certificate (generated if blank)"
   type        = "string"


### PR DESCRIPTION
* Add an `enable_aggregation` variable to enable the kube-apiserver aggregation layer for adding extension apiservers to clusters
* Aggregation is **disabled** by default. Typhoon recommends you not enable aggregation. Consider whether less invasive ways to achieve your goals are possible and whether those goals are well-founded
* Enabling aggregation and extension apiservers increases the attack surface of a cluster and makes extensions a part of the control plane. Admins must scrutinize and trust any extension apiserver used.
* Passing a v1.14 CNCF conformance test requires aggregation be enabled. Having an option for aggregation keeps compliance, but retains the stricter security posture on default clusters