### PR TITLE
Allow to specify a VIP to access the kube-apiserver

### DIFF
--- a/resources/manifests/kubeconfig-in-cluster.yaml
+++ b/resources/manifests/kubeconfig-in-cluster.yaml
@@ -11,7 +11,7 @@ data:
       cluster:
         # kubeconfig-in-cluster is for control plane components that must reach
         # kube-apiserver before service IPs are available (e.g.10.3.0.1)
-        server: ${server}
+        server: ${k8s_api_url}
         certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     users:
     - name: service-account

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -58,9 +58,10 @@ resource "tls_cert_request" "apiserver" {
     "kubernetes.default.svc.${var.cluster_domain_suffix}",
   ]
 
-  ip_addresses = [
+  ip_addresses = ["${compact(list(
+    "${var.lb_api_server_ip}",
     "${cidrhost(var.service_cidr, 1)}",
-  ]
+  ))}"]
 }
 
 resource "tls_locally_signed_cert" "apiserver" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "api_servers" {
   type        = "list"
 }
 
+variable "lb_api_server_ip" {
+  description = "IP of loadbalancer to access api server URL"
+  type        = "string"
+  default     = ""
+}
+
 variable "etcd_servers" {
   description = "List of URLs used to reach etcd servers."
   type        = "list"


### PR DESCRIPTION
* Add new variable $lb_api_server_ip to specify a loadbalancer IP to access the kube-apiserver