### PR TITLE
Remove unneeded advertise-address apiserver parameter

### DIFF
--- a/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -13,7 +13,6 @@ spec:
     command:
     - /hyperkube
     - apiserver
-    - --advertise-address=$(POD_IP)
     - --allow-privileged=true
     - --anonymous-auth=false
     - --authorization-mode=RBAC
@@ -35,11 +34,6 @@ spec:
     - --storage-backend=etcd3
     - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
     - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
-    env:
-    - name: POD_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
     volumeMounts:
     - name: secrets
       mountPath: /etc/kubernetes/secrets

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -39,7 +39,6 @@ spec:
         command:
         - /hyperkube
         - apiserver
-        - --advertise-address=$(POD_IP)
         - --allow-privileged=true
         - --anonymous-auth=false
         - --authorization-mode=RBAC
@@ -61,11 +60,6 @@ spec:
         - --storage-backend=etcd3
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
-        env:
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         volumeMounts:
         - name: secrets
           mountPath: /etc/kubernetes/secrets


### PR DESCRIPTION
In some case the POD_IP isn't set and the apiserver doesn't start.
Without the parameter apiserver use the default interface.