### PR TITLE
Update Calico from v3.6.1 to v3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Generate the assets.
 
 ```sh
 terraform init
-terraform get --update
 terraform plan
 terraform apply
 ```

--- a/conditional.tf
+++ b/conditional.tf
@@ -23,6 +23,10 @@ resource "template_dir" "calico-manifests" {
     calico_cni_image = "${var.container_images["calico_cni"]}"
 
     network_mtu                     = "${var.network_mtu}"
+    network_encapsulation           = "${indent(2, var.network_encapsulation == "vxlan" ? "vxlanMode: Always" : "ipipMode: Always")}"
+    ipip_enabled                   = "${var.network_encapsulation == "ipip" ? true : false}"
+    ipip_readiness                 = "${var.network_encapsulation == "ipip" ? indent(16, "- --bird-ready") : ""}"
+    vxlan_enabled                   = "${var.network_encapsulation == "vxlan" ? true : false}"
     network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
     pod_cidr                        = "${var.pod_cidr}"
     enable_reporting                = "${var.enable_reporting}"

--- a/resources/calico/cluster-role.yaml
+++ b/resources/calico/cluster-role.yaml
@@ -67,6 +67,7 @@ rules:
       - ipamblocks
       - globalnetworkpolicies
       - globalnetworksets
+      - networksets
       - networkpolicies
       - clusterinformations
       - hostendpoints
@@ -82,7 +83,7 @@ rules:
     verbs:
       - create
       - update
-  # Calico may perform IPAM allocations (not yet used)
+  # Calico may perform IPAM allocations
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities
@@ -99,6 +100,7 @@ rules:
       - ipamconfigs
     verbs:
       - get
+  # Watch block affinities for route aggregation
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities

--- a/resources/calico/daemonset.yaml
+++ b/resources/calico/daemonset.yaml
@@ -99,11 +99,20 @@ spec:
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
               value: "${network_ip_autodetection_method}"
-            # Enable IP-in-IP within Felix.
+            # Whether Felix should enable IP-in-IP tunnel
             - name: FELIX_IPINIPENABLED
-              value: "true"
-            # Set MTU for tunnel device used if ipip is enabled
+              value: "${ipip_enabled}"
+            # MTU to set on the IPIP tunnel (if enabled)
             - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Whether Felix should enable VXLAN tunnel
+            - name: FELIX_VXLANENABLED
+              value: "${vxlan_enabled}"
+            # MTU to set on the VXLAN tunnel (if enabled)
+            - name: FELIX_VXLANMTU
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
@@ -141,8 +150,8 @@ spec:
             exec:
               command:
                 - /bin/calico-node
-                - -bird-ready
                 - -felix-ready
+                ${ipip_readiness}
             periodSeconds: 10
           volumeMounts:
             - name: lib-modules

--- a/resources/calico/default-ipv4-ippool.yaml
+++ b/resources/calico/default-ipv4-ippool.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   blockSize: 24
   cidr: ${pod_cidr}
-  ipipMode: Always
+  ${network_encapsulation}
   natOutgoing: true
   nodeSelector: all()

--- a/resources/calico/networksets-crd.yaml
+++ b/resources/calico/networksets-crd.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkSet
+    plural: networksets
+    singular: networkset

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "network_mtu" {
   default     = "1500"
 }
 
+variable "network_encapsulation" {
+  description = "Network encapsulation mode either ipip or vxlan (only applies to calico)"
+  type        = "string"
+  default     = "ipip"
+}
+
 variable "network_ip_autodetection_method" {
   description = "Method to autodetect the host IPv4 address (only applies to calico)"
   type        = "string"
@@ -69,8 +75,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.6.1"
-    calico_cni       = "quay.io/calico/cni:v3.6.1"
+    calico           = "quay.io/calico/node:v3.7.0"
+    calico_cni       = "quay.io/calico/cni:v3.7.0"
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.3.0"


### PR DESCRIPTION
* Accept a `network_encapsulation` variable to choose whether the default IPPool should use ipip (default) or vxlan encapsulation
* Use `network_mtu` as the MTU for workload interfaces for ipip or vxlan (although Calico can have a IPPools with a mix, we're picking ipip xor vxlan)

Note: Its an aim to allow Calico (VXLAN) in Typhoon Azure and DigitalOcean (potentially displacing the Flannel default). Typhoon GCP, AWS, and bare-metal already default to Calico (IPIP) and will continue using IPIP mode (preferred, non-optional).
