### PR TITLE
Update Calico from v3.7.0 to v3.7.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -75,8 +75,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.7.0"
-    calico_cni       = "quay.io/calico/cni:v3.7.0"
+    calico           = "quay.io/calico/node:v3.7.1"
+    calico_cni       = "quay.io/calico/cni:v3.7.1"
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.3.0"


### PR DESCRIPTION
* https://github.com/projectcalico/calico/releases/tag/v3.7.1