### PR TITLE
Change flannel port from 8472 to 4789

### DIFF
--- a/resources/flannel/config.yaml
+++ b/resources/flannel/config.yaml
@@ -31,6 +31,7 @@ data:
     {
       "Network": "${pod_cidr}",
       "Backend": {
-        "Type": "vxlan"
+        "Type": "vxlan",
+        "Port": 4789
       }
     }


### PR DESCRIPTION
* Change flannel port from the kernel default 8472 to the IANA assigned VXLAN port 4789
* Requires a change to firewall rules or security groups depending on the platform (**action required!**)
* Why now? Calico now offers its own VXLAN backend so standardizing on the IANA port simplifies configuration
* https://github.com/coreos/flannel/blob/master/Documentation/backends.md#vxlan