### PR TITLE
 Migrate from Terraform v0.11 to v0.12 (breaking!)

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -3,16 +3,14 @@ resource "template_dir" "bootstrap-manifests" {
   source_dir      = "${path.module}/resources/bootstrap-manifests"
   destination_dir = "${var.asset_dir}/bootstrap-manifests"
 
-  vars {
-    hyperkube_image = "${var.container_images["hyperkube"]}"
-    etcd_servers    = "${join(",", formatlist("https://%s:2379", var.etcd_servers))}"
-
-    cloud_provider = "${var.cloud_provider}"
-    pod_cidr       = "${var.pod_cidr}"
-    service_cidr   = "${var.service_cidr}"
-
-    trusted_certs_dir = "${var.trusted_certs_dir}"
-    apiserver_port    = "${var.apiserver_port}"
+  vars = {
+    hyperkube_image   = var.container_images["hyperkube"]
+    etcd_servers      = join(",", formatlist("https://%s:2379", var.etcd_servers))
+    cloud_provider    = var.cloud_provider
+    pod_cidr          = var.pod_cidr
+    service_cidr      = var.service_cidr
+    trusted_certs_dir = var.trusted_certs_dir
+    apiserver_port    = var.apiserver_port
   }
 }
 
@@ -21,38 +19,37 @@ resource "template_dir" "manifests" {
   source_dir      = "${path.module}/resources/manifests"
   destination_dir = "${var.asset_dir}/manifests"
 
-  vars {
-    hyperkube_image        = "${var.container_images["hyperkube"]}"
-    pod_checkpointer_image = "${var.container_images["pod_checkpointer"]}"
-    coredns_image          = "${var.container_images["coredns"]}"
-
-    etcd_servers           = "${join(",", formatlist("https://%s:2379", var.etcd_servers))}"
-    control_plane_replicas = "${max(2, length(var.etcd_servers))}"
-
-    cloud_provider         = "${var.cloud_provider}"
-    pod_cidr               = "${var.pod_cidr}"
-    service_cidr           = "${var.service_cidr}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    trusted_certs_dir      = "${var.trusted_certs_dir}"
-    apiserver_port         = "${var.apiserver_port}"
-
-    ca_cert            = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
-    ca_key             = "${base64encode(tls_private_key.kube-ca.private_key_pem)}"
-    server             = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
-    apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
-    apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
-    serviceaccount_pub = "${base64encode(tls_private_key.service-account.public_key_pem)}"
-    serviceaccount_key = "${base64encode(tls_private_key.service-account.private_key_pem)}"
-
-    etcd_ca_cert     = "${base64encode(tls_self_signed_cert.etcd-ca.cert_pem)}"
-    etcd_client_cert = "${base64encode(tls_locally_signed_cert.client.cert_pem)}"
-    etcd_client_key  = "${base64encode(tls_private_key.client.private_key_pem)}"
-
-    aggregation_flags       = "${var.enable_aggregation == "true" ? indent(8, local.aggregation_flags) : ""}"
-    aggregation_ca_cert     = "${var.enable_aggregation == "true" ? base64encode(join(" ", tls_self_signed_cert.aggregation-ca.*.cert_pem)) : ""}"
-    aggregation_client_cert = "${var.enable_aggregation == "true" ? base64encode(join(" ", tls_locally_signed_cert.aggregation-client.*.cert_pem)) : ""}"
-    aggregation_client_key  = "${var.enable_aggregation == "true" ? base64encode(join(" ", tls_private_key.aggregation-client.*.private_key_pem)) : ""}"
+  vars = {
+    hyperkube_image        = var.container_images["hyperkube"]
+    pod_checkpointer_image = var.container_images["pod_checkpointer"]
+    coredns_image          = var.container_images["coredns"]
+    etcd_servers           = join(",", formatlist("https://%s:2379", var.etcd_servers))
+    control_plane_replicas = max(2, length(var.etcd_servers))
+    cloud_provider         = var.cloud_provider
+    pod_cidr               = var.pod_cidr
+    service_cidr           = var.service_cidr
+    cluster_domain_suffix  = var.cluster_domain_suffix
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    trusted_certs_dir      = var.trusted_certs_dir
+    apiserver_port         = var.apiserver_port
+    ca_cert                = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    ca_key                 = base64encode(tls_private_key.kube-ca.private_key_pem)
+    server                 = format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)
+    apiserver_key          = base64encode(tls_private_key.apiserver.private_key_pem)
+    apiserver_cert         = base64encode(tls_locally_signed_cert.apiserver.cert_pem)
+    serviceaccount_pub     = base64encode(tls_private_key.service-account.public_key_pem)
+    serviceaccount_key     = base64encode(tls_private_key.service-account.private_key_pem)
+    etcd_ca_cert           = base64encode(tls_self_signed_cert.etcd-ca.cert_pem)
+    etcd_client_cert       = base64encode(tls_locally_signed_cert.client.cert_pem)
+    etcd_client_key        = base64encode(tls_private_key.client.private_key_pem)
+    aggregation_flags      = var.enable_aggregation == "true" ? indent(8, local.aggregation_flags) : ""
+    aggregation_ca_cert    = var.enable_aggregation == "true" ? base64encode(join(" ", tls_self_signed_cert.aggregation-ca.*.cert_pem)) : ""
+    aggregation_client_cert = var.enable_aggregation == "true" ? base64encode(
+      join(" ", tls_locally_signed_cert.aggregation-client.*.cert_pem),
+    ) : ""
+    aggregation_client_key = var.enable_aggregation == "true" ? base64encode(
+      join(" ", tls_private_key.aggregation-client.*.private_key_pem),
+    ) : ""
   }
 }
 
@@ -64,47 +61,57 @@ locals {
 - --requestheader-client-ca-file=/etc/kubernetes/secrets/aggregation-ca.crt
 - --requestheader-extra-headers-prefix=X-Remote-Extra-
 - --requestheader-group-headers=X-Remote-Group
-- --requestheader-username-headers=X-Remote-UserEOF
+- --requestheader-username-headers=X-Remote-User
+EOF
 }
 
 # Generated kubeconfig for Kubelets
 resource "local_file" "kubeconfig-kubelet" {
-  content  = "${data.template_file.kubeconfig-kubelet.rendered}"
+  content = data.template_file.kubeconfig-kubelet.rendered
   filename = "${var.asset_dir}/auth/kubeconfig-kubelet"
 }
 
 # Generated admin kubeconfig (bootkube requires it be at auth/kubeconfig)
 # https://github.com/kubernetes-incubator/bootkube/blob/master/pkg/bootkube/bootkube.go#L42
 resource "local_file" "kubeconfig-admin" {
-  content  = "${data.template_file.kubeconfig-admin.rendered}"
+  content = data.template_file.kubeconfig-admin.rendered
   filename = "${var.asset_dir}/auth/kubeconfig"
 }
 
 # Generated admin kubeconfig in a file named after the cluster
 resource "local_file" "kubeconfig-admin-named" {
-  content  = "${data.template_file.kubeconfig-admin.rendered}"
+  content = data.template_file.kubeconfig-admin.rendered
   filename = "${var.asset_dir}/auth/${var.cluster_name}-config"
 }
 
 data "template_file" "kubeconfig-kubelet" {
-  template = "${file("${path.module}/resources/kubeconfig-kubelet")}"
+  template = file("${path.module}/resources/kubeconfig-kubelet")
 
-  vars {
-    ca_cert      = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
-    kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
-    kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
+  vars = {
+    ca_cert = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    kubelet_cert = base64encode(tls_locally_signed_cert.kubelet.cert_pem)
+    kubelet_key = base64encode(tls_private_key.kubelet.private_key_pem)
+    server = format(
+      "https://%s:%s",
+      element(var.api_servers, 0),
+      var.apiserver_port,
+    )
   }
 }
 
 data "template_file" "kubeconfig-admin" {
-  template = "${file("${path.module}/resources/kubeconfig-admin")}"
+  template = file("${path.module}/resources/kubeconfig-admin")
 
-  vars {
-    name         = "${var.cluster_name}"
-    ca_cert      = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
-    kubelet_cert = "${base64encode(tls_locally_signed_cert.admin.cert_pem)}"
-    kubelet_key  = "${base64encode(tls_private_key.admin.private_key_pem)}"
-    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
+  vars = {
+    name = var.cluster_name
+    ca_cert = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
+    kubelet_cert = base64encode(tls_locally_signed_cert.admin.cert_pem)
+    kubelet_key = base64encode(tls_private_key.admin.private_key_pem)
+    server = format(
+      "https://%s:%s",
+      element(var.api_servers, 0),
+      var.apiserver_port,
+    )
   }
 }
+

--- a/conditional.tf
+++ b/conditional.tf
@@ -1,47 +1,45 @@
 # Assets generated only when certain options are chosen
 
 resource "template_dir" "flannel-manifests" {
-  count           = "${var.networking == "flannel" ? 1 : 0}"
+  count           = var.networking == "flannel" ? 1 : 0
   source_dir      = "${path.module}/resources/flannel"
   destination_dir = "${var.asset_dir}/manifests-networking"
 
-  vars {
-    flannel_image     = "${var.container_images["flannel"]}"
-    flannel_cni_image = "${var.container_images["flannel_cni"]}"
-
-    pod_cidr = "${var.pod_cidr}"
+  vars = {
+    flannel_image     = var.container_images["flannel"]
+    flannel_cni_image = var.container_images["flannel_cni"]
+    pod_cidr          = var.pod_cidr
   }
 }
 
 resource "template_dir" "calico-manifests" {
-  count           = "${var.networking == "calico" ? 1 : 0}"
+  count           = var.networking == "calico" ? 1 : 0
   source_dir      = "${path.module}/resources/calico"
   destination_dir = "${var.asset_dir}/manifests-networking"
 
-  vars {
-    calico_image     = "${var.container_images["calico"]}"
-    calico_cni_image = "${var.container_images["calico_cni"]}"
-
-    network_mtu                     = "${var.network_mtu}"
-    network_encapsulation           = "${indent(2, var.network_encapsulation == "vxlan" ? "vxlanMode: Always" : "ipipMode: Always")}"
-    ipip_enabled                   = "${var.network_encapsulation == "ipip" ? true : false}"
-    ipip_readiness                 = "${var.network_encapsulation == "ipip" ? indent(16, "- --bird-ready") : ""}"
-    vxlan_enabled                   = "${var.network_encapsulation == "vxlan" ? true : false}"
-    network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
-    pod_cidr                        = "${var.pod_cidr}"
-    enable_reporting                = "${var.enable_reporting}"
+  vars = {
+    calico_image                    = var.container_images["calico"]
+    calico_cni_image                = var.container_images["calico_cni"]
+    network_mtu                     = var.network_mtu
+    network_encapsulation           = indent(2, var.network_encapsulation == "vxlan" ? "vxlanMode: Always" : "ipipMode: Always")
+    ipip_enabled                    = var.network_encapsulation == "ipip" ? true : false
+    ipip_readiness                  = var.network_encapsulation == "ipip" ? indent(16, "- --bird-ready") : ""
+    vxlan_enabled                   = var.network_encapsulation == "vxlan" ? true : false
+    network_ip_autodetection_method = var.network_ip_autodetection_method
+    pod_cidr                        = var.pod_cidr
+    enable_reporting                = var.enable_reporting
   }
 }
 
 resource "template_dir" "kube-router-manifests" {
-  count           = "${var.networking == "kube-router" ? 1 : 0}"
+  count           = var.networking == "kube-router" ? 1 : 0
   source_dir      = "${path.module}/resources/kube-router"
   destination_dir = "${var.asset_dir}/manifests-networking"
 
-  vars {
-    kube_router_image = "${var.container_images["kube_router"]}"
-    flannel_cni_image = "${var.container_images["flannel_cni"]}"
-
-    network_mtu = "${var.network_mtu}"
+  vars = {
+    kube_router_image = var.container_images["kube_router"]
+    flannel_cni_image = var.container_images["flannel_cni"]
+    network_mtu       = var.network_mtu
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,53 +1,53 @@
 output "id" {
-  value = "${sha1("${template_dir.bootstrap-manifests.id} ${template_dir.manifests.id}")}"
+  value = sha1("${template_dir.bootstrap-manifests.id} ${template_dir.manifests.id}")
 }
 
 output "content_hash" {
-  value = "${sha1("${template_dir.bootstrap-manifests.id} ${template_dir.manifests.id}")}"
+  value = sha1("${template_dir.bootstrap-manifests.id} ${template_dir.manifests.id}")
 }
 
 output "cluster_dns_service_ip" {
-  value = "${cidrhost(var.service_cidr, 10)}"
+  value = cidrhost(var.service_cidr, 10)
 }
 
 // Generated kubeconfig for Kubelets (i.e. lower privilege than admin)
 output "kubeconfig-kubelet" {
-  value = "${data.template_file.kubeconfig-kubelet.rendered}"
+  value = data.template_file.kubeconfig-kubelet.rendered
 }
 
 // Generated kubeconfig for admins (i.e. human super-user)
 output "kubeconfig-admin" {
-  value = "${data.template_file.kubeconfig-admin.rendered}"
+  value = data.template_file.kubeconfig-admin.rendered
 }
 
 # etcd TLS assets
 
 output "etcd_ca_cert" {
-  value = "${tls_self_signed_cert.etcd-ca.cert_pem}"
+  value = tls_self_signed_cert.etcd-ca.cert_pem
 }
 
 output "etcd_client_cert" {
-  value = "${tls_locally_signed_cert.client.cert_pem}"
+  value = tls_locally_signed_cert.client.cert_pem
 }
 
 output "etcd_client_key" {
-  value = "${tls_private_key.client.private_key_pem}"
+  value = tls_private_key.client.private_key_pem
 }
 
 output "etcd_server_cert" {
-  value = "${tls_locally_signed_cert.server.cert_pem}"
+  value = tls_locally_signed_cert.server.cert_pem
 }
 
 output "etcd_server_key" {
-  value = "${tls_private_key.server.private_key_pem}"
+  value = tls_private_key.server.private_key_pem
 }
 
 output "etcd_peer_cert" {
-  value = "${tls_locally_signed_cert.peer.cert_pem}"
+  value = tls_locally_signed_cert.peer.cert_pem
 }
 
 output "etcd_peer_key" {
-  value = "${tls_private_key.peer.private_key_pem}"
+  value = tls_private_key.peer.private_key_pem
 }
 
 # Some platforms may need to reconstruct the kubeconfig directly in user-data.
@@ -55,17 +55,18 @@ output "etcd_peer_key" {
 # contents so the raw components of the kubeconfig may be needed.
 
 output "ca_cert" {
-  value = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
+  value = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
 }
 
 output "kubelet_cert" {
-  value = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
+  value = base64encode(tls_locally_signed_cert.kubelet.cert_pem)
 }
 
 output "kubelet_key" {
-  value = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
+  value = base64encode(tls_private_key.kubelet.private_key_pem)
 }
 
 output "server" {
-  value = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
+  value = format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)
 }
+

--- a/require.tf
+++ b/require.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = "~> 0.12.0"
+}

--- a/require.tf
+++ b/require.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = "~> 0.12.0"
-}

--- a/tls-aggregation.tf
+++ b/tls-aggregation.tf
@@ -1,27 +1,18 @@
-# NOTE: Across this module, the following workaround is used:
-# `"${var.some_var == "condition" ? join(" ", tls_private_key.aggregation-ca.*.private_key_pem) : ""}"`
-# Due to https://github.com/hashicorp/hil/issues/50, both sides of conditions
-# are evaluated, until one of them is discarded. When a `count` is used resources
-# can be referenced as lists with the `.*` notation, and arrays are allowed to be
-# empty. The `join()` interpolation function is then used to cast them back to
-# a string. Since `count` can only be 0 or 1, the returned value is either empty
-# (and discarded anyways) or the desired value.
-
 # Kubernetes Aggregation CA (i.e. front-proxy-ca)
 # Files: tls/{aggregation-ca.crt,aggregation-ca.key}
 
 resource "tls_private_key" "aggregation-ca" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_self_signed_cert" "aggregation-ca" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
-  key_algorithm   = "${tls_private_key.aggregation-ca.algorithm}"
-  private_key_pem = "${tls_private_key.aggregation-ca.private_key_pem}"
+  key_algorithm   = tls_private_key.aggregation-ca[0].algorithm
+  private_key_pem = tls_private_key.aggregation-ca[0].private_key_pem
 
   subject {
     common_name = "kubernetes-front-proxy-ca"
@@ -38,16 +29,16 @@ resource "tls_self_signed_cert" "aggregation-ca" {
 }
 
 resource "local_file" "aggregation-ca-key" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
-  content  = "${tls_private_key.aggregation-ca.private_key_pem}"
+  content  = tls_private_key.aggregation-ca[0].private_key_pem
   filename = "${var.asset_dir}/tls/aggregation-ca.key"
 }
 
 resource "local_file" "aggregation-ca-crt" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
-  content  = "${tls_self_signed_cert.aggregation-ca.cert_pem}"
+  content  = tls_self_signed_cert.aggregation-ca[0].cert_pem
   filename = "${var.asset_dir}/tls/aggregation-ca.crt"
 }
 
@@ -55,17 +46,17 @@ resource "local_file" "aggregation-ca-crt" {
 # Files: tls/{aggregation-client.crt,aggregation-client.key}
 
 resource "tls_private_key" "aggregation-client" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "aggregation-client" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
-  key_algorithm   = "${tls_private_key.aggregation-client.algorithm}"
-  private_key_pem = "${tls_private_key.aggregation-client.private_key_pem}"
+  key_algorithm   = tls_private_key.aggregation-client[0].algorithm
+  private_key_pem = tls_private_key.aggregation-client[0].private_key_pem
 
   subject {
     common_name = "kube-apiserver"
@@ -73,13 +64,13 @@ resource "tls_cert_request" "aggregation-client" {
 }
 
 resource "tls_locally_signed_cert" "aggregation-client" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
-  cert_request_pem = "${tls_cert_request.aggregation-client.cert_request_pem}"
+  cert_request_pem = tls_cert_request.aggregation-client[0].cert_request_pem
 
-  ca_key_algorithm   = "${tls_self_signed_cert.aggregation-ca.key_algorithm}"
-  ca_private_key_pem = "${tls_private_key.aggregation-ca.private_key_pem}"
-  ca_cert_pem        = "${tls_self_signed_cert.aggregation-ca.cert_pem}"
+  ca_key_algorithm   = tls_self_signed_cert.aggregation-ca[0].key_algorithm
+  ca_private_key_pem = tls_private_key.aggregation-ca[0].private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.aggregation-ca[0].cert_pem
 
   validity_period_hours = 8760
 
@@ -91,15 +82,16 @@ resource "tls_locally_signed_cert" "aggregation-client" {
 }
 
 resource "local_file" "aggregation-client-key" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
-  content  = "${tls_private_key.aggregation-client.private_key_pem}"
+  content  = tls_private_key.aggregation-client[0].private_key_pem
   filename = "${var.asset_dir}/tls/aggregation-client.key"
 }
 
 resource "local_file" "aggregation-client-crt" {
-  count = "${var.enable_aggregation == "true" ? 1 : 0}"
+  count = var.enable_aggregation == "true" ? 1 : 0
 
-  content  = "${tls_locally_signed_cert.aggregation-client.cert_pem}"
+  content  = tls_locally_signed_cert.aggregation-client[0].cert_pem
   filename = "${var.asset_dir}/tls/aggregation-client.crt"
 }
+

--- a/tls-etcd.tf
+++ b/tls-etcd.tf
@@ -1,66 +1,66 @@
 # etcd-ca.crt
 resource "local_file" "etcd_ca_crt" {
-  content  = "${tls_self_signed_cert.etcd-ca.cert_pem}"
+  content  = tls_self_signed_cert.etcd-ca.cert_pem
   filename = "${var.asset_dir}/tls/etcd-ca.crt"
 }
 
 # etcd-ca.key
 resource "local_file" "etcd_ca_key" {
-  content  = "${tls_private_key.etcd-ca.private_key_pem}"
+  content  = tls_private_key.etcd-ca.private_key_pem
   filename = "${var.asset_dir}/tls/etcd-ca.key"
 }
 
 # etcd-client-ca.crt
 resource "local_file" "etcd_client_ca_crt" {
-  content  = "${tls_self_signed_cert.etcd-ca.cert_pem}"
+  content  = tls_self_signed_cert.etcd-ca.cert_pem
   filename = "${var.asset_dir}/tls/etcd-client-ca.crt"
 }
 
 # etcd-client.crt
 resource "local_file" "etcd_client_crt" {
-  content  = "${tls_locally_signed_cert.client.cert_pem}"
+  content  = tls_locally_signed_cert.client.cert_pem
   filename = "${var.asset_dir}/tls/etcd-client.crt"
 }
 
 # etcd-client.key
 resource "local_file" "etcd_client_key" {
-  content  = "${tls_private_key.client.private_key_pem}"
+  content  = tls_private_key.client.private_key_pem
   filename = "${var.asset_dir}/tls/etcd-client.key"
 }
 
 # server-ca.crt
 resource "local_file" "etcd_server_ca_crt" {
-  content  = "${tls_self_signed_cert.etcd-ca.cert_pem}"
+  content  = tls_self_signed_cert.etcd-ca.cert_pem
   filename = "${var.asset_dir}/tls/etcd/server-ca.crt"
 }
 
 # server.crt
 resource "local_file" "etcd_server_crt" {
-  content  = "${tls_locally_signed_cert.server.cert_pem}"
+  content  = tls_locally_signed_cert.server.cert_pem
   filename = "${var.asset_dir}/tls/etcd/server.crt"
 }
 
 # server.key
 resource "local_file" "etcd_server_key" {
-  content  = "${tls_private_key.server.private_key_pem}"
+  content  = tls_private_key.server.private_key_pem
   filename = "${var.asset_dir}/tls/etcd/server.key"
 }
 
 # peer-ca.crt
 resource "local_file" "etcd_peer_ca_crt" {
-  content  = "${tls_self_signed_cert.etcd-ca.cert_pem}"
+  content  = tls_self_signed_cert.etcd-ca.cert_pem
   filename = "${var.asset_dir}/tls/etcd/peer-ca.crt"
 }
 
 # peer.crt
 resource "local_file" "etcd_peer_crt" {
-  content  = "${tls_locally_signed_cert.peer.cert_pem}"
+  content  = tls_locally_signed_cert.peer.cert_pem
   filename = "${var.asset_dir}/tls/etcd/peer.crt"
 }
 
 # peer.key
 resource "local_file" "etcd_peer_key" {
-  content  = "${tls_private_key.peer.private_key_pem}"
+  content  = tls_private_key.peer.private_key_pem
   filename = "${var.asset_dir}/tls/etcd/peer.key"
 }
 
@@ -72,8 +72,8 @@ resource "tls_private_key" "etcd-ca" {
 }
 
 resource "tls_self_signed_cert" "etcd-ca" {
-  key_algorithm   = "${tls_private_key.etcd-ca.algorithm}"
-  private_key_pem = "${tls_private_key.etcd-ca.private_key_pem}"
+  key_algorithm   = tls_private_key.etcd-ca.algorithm
+  private_key_pem = tls_private_key.etcd-ca.private_key_pem
 
   subject {
     common_name  = "etcd-ca"
@@ -98,8 +98,8 @@ resource "tls_private_key" "client" {
 }
 
 resource "tls_cert_request" "client" {
-  key_algorithm   = "${tls_private_key.client.algorithm}"
-  private_key_pem = "${tls_private_key.client.private_key_pem}"
+  key_algorithm   = tls_private_key.client.algorithm
+  private_key_pem = tls_private_key.client.private_key_pem
 
   subject {
     common_name  = "etcd-client"
@@ -110,19 +110,15 @@ resource "tls_cert_request" "client" {
     "127.0.0.1",
   ]
 
-  dns_names = ["${concat(
-    var.etcd_servers,
-    list(
-      "localhost",
-    ))}"]
+  dns_names = concat(var.etcd_servers, ["localhost"])
 }
 
 resource "tls_locally_signed_cert" "client" {
-  cert_request_pem = "${tls_cert_request.client.cert_request_pem}"
+  cert_request_pem = tls_cert_request.client.cert_request_pem
 
-  ca_key_algorithm   = "${join(" ", tls_self_signed_cert.etcd-ca.*.key_algorithm)}"
-  ca_private_key_pem = "${join(" ", tls_private_key.etcd-ca.*.private_key_pem)}"
-  ca_cert_pem        = "${join(" ", tls_self_signed_cert.etcd-ca.*.cert_pem)}"
+  ca_key_algorithm   = tls_self_signed_cert.etcd-ca.key_algorithm
+  ca_private_key_pem = tls_private_key.etcd-ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.etcd-ca.cert_pem
 
   validity_period_hours = 8760
 
@@ -140,8 +136,8 @@ resource "tls_private_key" "server" {
 }
 
 resource "tls_cert_request" "server" {
-  key_algorithm   = "${tls_private_key.server.algorithm}"
-  private_key_pem = "${tls_private_key.server.private_key_pem}"
+  key_algorithm   = tls_private_key.server.algorithm
+  private_key_pem = tls_private_key.server.private_key_pem
 
   subject {
     common_name  = "etcd-server"
@@ -152,19 +148,15 @@ resource "tls_cert_request" "server" {
     "127.0.0.1",
   ]
 
-  dns_names = ["${concat(
-    var.etcd_servers,
-    list(
-      "localhost",
-    ))}"]
+  dns_names = concat(var.etcd_servers, ["localhost"])
 }
 
 resource "tls_locally_signed_cert" "server" {
-  cert_request_pem = "${tls_cert_request.server.cert_request_pem}"
+  cert_request_pem = tls_cert_request.server.cert_request_pem
 
-  ca_key_algorithm   = "${join(" ", tls_self_signed_cert.etcd-ca.*.key_algorithm)}"
-  ca_private_key_pem = "${join(" ", tls_private_key.etcd-ca.*.private_key_pem)}"
-  ca_cert_pem        = "${join(" ", tls_self_signed_cert.etcd-ca.*.cert_pem)}"
+  ca_key_algorithm   = tls_self_signed_cert.etcd-ca.key_algorithm
+  ca_private_key_pem = tls_private_key.etcd-ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.etcd-ca.cert_pem
 
   validity_period_hours = 8760
 
@@ -182,23 +174,23 @@ resource "tls_private_key" "peer" {
 }
 
 resource "tls_cert_request" "peer" {
-  key_algorithm   = "${tls_private_key.peer.algorithm}"
-  private_key_pem = "${tls_private_key.peer.private_key_pem}"
+  key_algorithm   = tls_private_key.peer.algorithm
+  private_key_pem = tls_private_key.peer.private_key_pem
 
   subject {
     common_name  = "etcd-peer"
     organization = "etcd"
   }
 
-  dns_names = ["${var.etcd_servers}"]
+  dns_names = var.etcd_servers
 }
 
 resource "tls_locally_signed_cert" "peer" {
-  cert_request_pem = "${tls_cert_request.peer.cert_request_pem}"
+  cert_request_pem = tls_cert_request.peer.cert_request_pem
 
-  ca_key_algorithm   = "${join(" ", tls_self_signed_cert.etcd-ca.*.key_algorithm)}"
-  ca_private_key_pem = "${join(" ", tls_private_key.etcd-ca.*.private_key_pem)}"
-  ca_cert_pem        = "${join(" ", tls_self_signed_cert.etcd-ca.*.cert_pem)}"
+  ca_key_algorithm   = tls_self_signed_cert.etcd-ca.key_algorithm
+  ca_private_key_pem = tls_private_key.etcd-ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.etcd-ca.cert_pem
 
   validity_period_hours = 8760
 
@@ -209,3 +201,4 @@ resource "tls_locally_signed_cert" "peer" {
     "client_auth",
   ]
 }
+

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -6,8 +6,8 @@ resource "tls_private_key" "kube-ca" {
 }
 
 resource "tls_self_signed_cert" "kube-ca" {
-  key_algorithm   = "${tls_private_key.kube-ca.algorithm}"
-  private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
+  key_algorithm   = tls_private_key.kube-ca.algorithm
+  private_key_pem = tls_private_key.kube-ca.private_key_pem
 
   subject {
     common_name  = "kubernetes-ca"
@@ -25,12 +25,12 @@ resource "tls_self_signed_cert" "kube-ca" {
 }
 
 resource "local_file" "kube-ca-key" {
-  content  = "${tls_private_key.kube-ca.private_key_pem}"
+  content  = tls_private_key.kube-ca.private_key_pem
   filename = "${var.asset_dir}/tls/ca.key"
 }
 
 resource "local_file" "kube-ca-crt" {
-  content  = "${tls_self_signed_cert.kube-ca.cert_pem}"
+  content  = tls_self_signed_cert.kube-ca.cert_pem
   filename = "${var.asset_dir}/tls/ca.crt"
 }
 
@@ -42,33 +42,33 @@ resource "tls_private_key" "apiserver" {
 }
 
 resource "tls_cert_request" "apiserver" {
-  key_algorithm   = "${tls_private_key.apiserver.algorithm}"
-  private_key_pem = "${tls_private_key.apiserver.private_key_pem}"
+  key_algorithm   = tls_private_key.apiserver.algorithm
+  private_key_pem = tls_private_key.apiserver.private_key_pem
 
   subject {
     common_name  = "kube-apiserver"
     organization = "system:masters"
   }
 
-  dns_names = [
-    "${var.api_servers}",
+  dns_names = flatten([
+    var.api_servers,
     "kubernetes",
     "kubernetes.default",
     "kubernetes.default.svc",
     "kubernetes.default.svc.${var.cluster_domain_suffix}",
-  ]
+  ])
 
   ip_addresses = [
-    "${cidrhost(var.service_cidr, 1)}",
+    cidrhost(var.service_cidr, 1),
   ]
 }
 
 resource "tls_locally_signed_cert" "apiserver" {
-  cert_request_pem = "${tls_cert_request.apiserver.cert_request_pem}"
+  cert_request_pem = tls_cert_request.apiserver.cert_request_pem
 
-  ca_key_algorithm   = "${tls_self_signed_cert.kube-ca.key_algorithm}"
-  ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
-  ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
+  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
+  ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
 
   validity_period_hours = 8760
 
@@ -81,12 +81,12 @@ resource "tls_locally_signed_cert" "apiserver" {
 }
 
 resource "local_file" "apiserver-key" {
-  content  = "${tls_private_key.apiserver.private_key_pem}"
+  content  = tls_private_key.apiserver.private_key_pem
   filename = "${var.asset_dir}/tls/apiserver.key"
 }
 
 resource "local_file" "apiserver-crt" {
-  content  = "${tls_locally_signed_cert.apiserver.cert_pem}"
+  content  = tls_locally_signed_cert.apiserver.cert_pem
   filename = "${var.asset_dir}/tls/apiserver.crt"
 }
 
@@ -98,8 +98,8 @@ resource "tls_private_key" "admin" {
 }
 
 resource "tls_cert_request" "admin" {
-  key_algorithm   = "${tls_private_key.admin.algorithm}"
-  private_key_pem = "${tls_private_key.admin.private_key_pem}"
+  key_algorithm   = tls_private_key.admin.algorithm
+  private_key_pem = tls_private_key.admin.private_key_pem
 
   subject {
     common_name  = "kubernetes-admin"
@@ -108,11 +108,11 @@ resource "tls_cert_request" "admin" {
 }
 
 resource "tls_locally_signed_cert" "admin" {
-  cert_request_pem = "${tls_cert_request.admin.cert_request_pem}"
+  cert_request_pem = tls_cert_request.admin.cert_request_pem
 
-  ca_key_algorithm   = "${tls_self_signed_cert.kube-ca.key_algorithm}"
-  ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
-  ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
+  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
+  ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
 
   validity_period_hours = 8760
 
@@ -124,12 +124,12 @@ resource "tls_locally_signed_cert" "admin" {
 }
 
 resource "local_file" "admin-key" {
-  content  = "${tls_private_key.admin.private_key_pem}"
+  content  = tls_private_key.admin.private_key_pem
   filename = "${var.asset_dir}/tls/admin.key"
 }
 
 resource "local_file" "admin-crt" {
-  content  = "${tls_locally_signed_cert.admin.cert_pem}"
+  content  = tls_locally_signed_cert.admin.cert_pem
   filename = "${var.asset_dir}/tls/admin.crt"
 }
 
@@ -141,12 +141,12 @@ resource "tls_private_key" "service-account" {
 }
 
 resource "local_file" "service-account-key" {
-  content  = "${tls_private_key.service-account.private_key_pem}"
+  content  = tls_private_key.service-account.private_key_pem
   filename = "${var.asset_dir}/tls/service-account.key"
 }
 
 resource "local_file" "service-account-crt" {
-  content  = "${tls_private_key.service-account.public_key_pem}"
+  content  = tls_private_key.service-account.public_key_pem
   filename = "${var.asset_dir}/tls/service-account.pub"
 }
 
@@ -158,8 +158,8 @@ resource "tls_private_key" "kubelet" {
 }
 
 resource "tls_cert_request" "kubelet" {
-  key_algorithm   = "${tls_private_key.kubelet.algorithm}"
-  private_key_pem = "${tls_private_key.kubelet.private_key_pem}"
+  key_algorithm   = tls_private_key.kubelet.algorithm
+  private_key_pem = tls_private_key.kubelet.private_key_pem
 
   subject {
     common_name  = "kubelet"
@@ -168,11 +168,11 @@ resource "tls_cert_request" "kubelet" {
 }
 
 resource "tls_locally_signed_cert" "kubelet" {
-  cert_request_pem = "${tls_cert_request.kubelet.cert_request_pem}"
+  cert_request_pem = tls_cert_request.kubelet.cert_request_pem
 
-  ca_key_algorithm   = "${tls_self_signed_cert.kube-ca.key_algorithm}"
-  ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
-  ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
+  ca_key_algorithm   = tls_self_signed_cert.kube-ca.key_algorithm
+  ca_private_key_pem = tls_private_key.kube-ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.kube-ca.cert_pem
 
   validity_period_hours = 8760
 
@@ -185,11 +185,12 @@ resource "tls_locally_signed_cert" "kubelet" {
 }
 
 resource "local_file" "kubelet-key" {
-  content  = "${tls_private_key.kubelet.private_key_pem}"
+  content  = tls_private_key.kubelet.private_key_pem
   filename = "${var.asset_dir}/tls/kubelet.key"
 }
 
 resource "local_file" "kubelet-crt" {
-  content  = "${tls_locally_signed_cert.kubelet.cert_pem}"
+  content  = tls_locally_signed_cert.kubelet.cert_pem
   filename = "${var.asset_dir}/tls/kubelet.crt"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,56 +1,56 @@
 variable "cluster_name" {
   description = "Cluster name"
-  type        = "string"
+  type        = string
 }
 
 variable "api_servers" {
   description = "List of URLs used to reach kube-apiserver"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "etcd_servers" {
   description = "List of URLs used to reach etcd servers."
-  type        = "list"
+  type        = list(string)
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "cloud_provider" {
   description = "The provider for cloud services (empty string for no provider)"
-  type        = "string"
+  type        = string
   default     = ""
 }
 
 variable "networking" {
   description = "Choice of networking provider (flannel or calico or kube-router)"
-  type        = "string"
+  type        = string
   default     = "flannel"
 }
 
 variable "network_mtu" {
   description = "CNI interface MTU (only applies to calico and kube-router)"
-  type        = "string"
+  type        = string
   default     = "1500"
 }
 
 variable "network_encapsulation" {
   description = "Network encapsulation mode either ipip or vxlan (only applies to calico)"
-  type        = "string"
+  type        = string
   default     = "ipip"
 }
 
 variable "network_ip_autodetection_method" {
   description = "Method to autodetect the host IPv4 address (only applies to calico)"
-  type        = "string"
+  type        = string
   default     = "first-found"
 }
 
 variable "pod_cidr" {
   description = "CIDR IP range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -60,54 +60,56 @@ CIDR IP range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for kube-dns.
 EOD
 
-  type    = "string"
+
+  type = string
   default = "10.3.0.0/24"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by kube-dns"
-  type        = "string"
-  default     = "cluster.local"
+  type = string
+  default = "cluster.local"
 }
 
 variable "container_images" {
   description = "Container images to use"
-  type        = "map"
+  type = map(string)
 
   default = {
-    calico           = "quay.io/calico/node:v3.7.2"
-    calico_cni       = "quay.io/calico/cni:v3.7.2"
-    flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
-    flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
-    kube_router      = "cloudnativelabs/kube-router:v0.3.1"
-    hyperkube        = "k8s.gcr.io/hyperkube:v1.14.3"
-    coredns          = "k8s.gcr.io/coredns:1.5.0"
+    calico = "quay.io/calico/node:v3.7.2"
+    calico_cni = "quay.io/calico/cni:v3.7.2"
+    flannel = "quay.io/coreos/flannel:v0.11.0-amd64"
+    flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
+    kube_router = "cloudnativelabs/kube-router:v0.3.1"
+    hyperkube = "k8s.gcr.io/hyperkube:v1.14.3"
+    coredns = "k8s.gcr.io/coredns:1.5.0"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type = string
   description = "Enable usage or analytics reporting to upstream component owners (Tigera: Calico)"
-  default     = "false"
+  default = "false"
 }
 
 variable "trusted_certs_dir" {
   description = "Path to the directory on cluster nodes where trust TLS certs are kept"
-  type        = "string"
-  default     = "/usr/share/ca-certificates"
+  type = string
+  default = "/usr/share/ca-certificates"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false, recommended)"
-  type        = "string"
-  default     = "false"
+  type = string
+  default = "false"
 }
 
 # unofficial, temporary, may be removed without notice
 
 variable "apiserver_port" {
   description = "kube-apiserver port"
-  type        = "string"
-  default     = "6443"
+  type = string
+  default = "6443"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+# Terraform version and plugin versions
+
+terraform {
+  required_version = "~> 0.12.0"
+  required_providers {
+    local    = "~> 1.2"
+    template = "~> 2.1"
+    tls      = "~> 2.0"
+  }
+}


### PR DESCRIPTION
* [Terraform v0.12](https://www.terraform.io/upgrade-guides/0-12.html#upgrades-for-reusable-modules) is a major Terraform release with breaking changes to the HCL language. In v0.11, it was required to use redundant brackets as interpreter type hints to pass lists or concat and flatten lists and strings. In v0.12, that work-around is no longer supported. Lists are represented as first-class objects and the redundant brackets create nested lists. Consequently, its not possible to pass lists in a way that works with both v0.11 and v0.12 at the same time. We've made the difficult choice to pursue a hard cutover to Terraform v0.12.x
* https://www.terraform.io/upgrade-guides/0-12.html#referring-to-list-variables
* Use expression syntax instead of interpolated strings, where suggested
* Define Terraform required_version ~> v0.12.0 (> v0.12, < v0.13)
* Define required provider versions for the module (local, template, tls)