### PR TITLE
Always run kube-apiserver on port 6443 (internally)

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -10,7 +10,6 @@ resource "template_dir" "bootstrap-manifests" {
     pod_cidr          = var.pod_cidr
     service_cidr      = var.service_cidr
     trusted_certs_dir = var.trusted_certs_dir
-    apiserver_port    = var.apiserver_port
   }
 }
 
@@ -31,10 +30,9 @@ resource "template_dir" "manifests" {
     cluster_domain_suffix  = var.cluster_domain_suffix
     cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
     trusted_certs_dir      = var.trusted_certs_dir
-    apiserver_port         = var.apiserver_port
     ca_cert                = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
     ca_key                 = base64encode(tls_private_key.kube-ca.private_key_pem)
-    server                 = format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)
+    server                 = format("https://%s:%s", element(var.api_servers, 0), var.external_apiserver_port)
     apiserver_key          = base64encode(tls_private_key.apiserver.private_key_pem)
     apiserver_cert         = base64encode(tls_locally_signed_cert.apiserver.cert_pem)
     serviceaccount_pub     = base64encode(tls_private_key.service-account.public_key_pem)
@@ -91,11 +89,7 @@ data "template_file" "kubeconfig-kubelet" {
     ca_cert = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
     kubelet_cert = base64encode(tls_locally_signed_cert.kubelet.cert_pem)
     kubelet_key = base64encode(tls_private_key.kubelet.private_key_pem)
-    server = format(
-      "https://%s:%s",
-      element(var.api_servers, 0),
-      var.apiserver_port,
-    )
+    server = format("https://%s:%s", element(var.api_servers, 0), var.external_apiserver_port)
   }
 }
 
@@ -107,11 +101,7 @@ data "template_file" "kubeconfig-admin" {
     ca_cert = base64encode(tls_self_signed_cert.kube-ca.cert_pem)
     kubelet_cert = base64encode(tls_locally_signed_cert.admin.cert_pem)
     kubelet_key = base64encode(tls_private_key.admin.private_key_pem)
-    server = format(
-      "https://%s:%s",
-      element(var.api_servers, 0),
-      var.apiserver_port,
-    )
+    server = format("https://%s:%s", element(var.api_servers, 0), var.external_apiserver_port)
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -67,6 +67,6 @@ output "kubelet_key" {
 }
 
 output "server" {
-  value = format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)
+  value = format("https://%s:%s", element(var.api_servers, 0), var.external_apiserver_port)
 }
 

--- a/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -29,7 +29,7 @@ spec:
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-    - --secure-port=${apiserver_port}
+    - --secure-port=6443
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
     - --service-cluster-ip-range=${service_cidr}
     - --storage-backend=etcd3

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -55,7 +55,7 @@ spec:
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname${aggregation_flags}
-        - --secure-port=${apiserver_port}
+        - --secure-port=6443
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --service-cluster-ip-range=${service_cidr}
         - --storage-backend=etcd3

--- a/variables.tf
+++ b/variables.tf
@@ -107,8 +107,8 @@ variable "enable_aggregation" {
 
 # unofficial, temporary, may be removed without notice
 
-variable "apiserver_port" {
-  description = "kube-apiserver port"
+variable "external_apiserver_port" {
+  description = "External kube-apiserver port (e.g. 6443 to match internal kube-apiserver port)"
   type = string
   default = "6443"
 }


### PR DESCRIPTION
* Require bootstrap-kube-apiserver and kube-apiserver components listen on port 6443 (internally) to allow kube-apiserver pods to run with lower user privilege
* Remove variable `apiserver_port`. The kube-apiserver listen port is no longer customizable.
* Add variable `external_apiserver_port` to allow architectures where a load balancer fronts kube-apiserver 6443 backends, but listens on a different port externally. For example, Google Cloud TCP Proxy load balancers cannot listen on 6443