### PR TITLE
Run kube-apiserver as non-root user (nobody)

### DIFF
--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -73,6 +73,9 @@ spec:
         - name: ssl-certs-host
           mountPath: /etc/ssl/certs
           readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       volumes:
       - name: secrets
         secret:


### PR DESCRIPTION
* Run `kube-apiserver` as a non-root user (nobody). `kube-apiserver` no longer needs to bind low numbered ports (previously for GCP).