### PR TITLE
Upgrade Calico from v3.7.4 to v3.8.0

### DIFF
--- a/resources/calico/config.yaml
+++ b/resources/calico/config.yaml
@@ -36,6 +36,10 @@ data:
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
         }
       ]
     }

--- a/resources/kube-router/cluster-role.yaml
+++ b/resources/kube-router/cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kube-router

--- a/variables.tf
+++ b/variables.tf
@@ -76,8 +76,8 @@ variable "container_images" {
   type = map(string)
 
   default = {
-    calico = "quay.io/calico/node:v3.7.4"
-    calico_cni = "quay.io/calico/cni:v3.7.4"
+    calico = "quay.io/calico/node:v3.8.0"
+    calico_cni = "quay.io/calico/cni:v3.8.0"
     flannel = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router = "cloudnativelabs/kube-router:v0.3.1"


### PR DESCRIPTION
* Enable CNI bandwidth plugin for traffic shaping
* https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-traffic-shaping