### PR TITLE
Update Calico from v3.8.0 to v3.8.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -76,8 +76,8 @@ variable "container_images" {
   type = map(string)
 
   default = {
-    calico = "quay.io/calico/node:v3.8.0"
-    calico_cni = "quay.io/calico/cni:v3.8.0"
+    calico = "quay.io/calico/node:v3.8.1"
+    calico_cni = "quay.io/calico/cni:v3.8.1"
     flannel = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router = "cloudnativelabs/kube-router:v0.3.2"


### PR DESCRIPTION
* https://github.com/projectcalico/calico/releases/tag/v3.8.1