### PR TITLE
Update CoreDNS from v1.5.0 to v1.6.2

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,7 @@ variable "container_images" {
     flannel_cni = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router = "cloudnativelabs/kube-router:v0.3.2"
     hyperkube = "k8s.gcr.io/hyperkube:v1.15.3"
-    coredns = "k8s.gcr.io/coredns:1.5.0"
+    coredns = "k8s.gcr.io/coredns:1.6.2"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }
 }


### PR DESCRIPTION
* https://coredns.io/2019/06/26/coredns-1.5.1-release/
* https://coredns.io/2019/07/03/coredns-1.5.2-release/
* https://coredns.io/2019/07/28/coredns-1.6.0-release/
* https://coredns.io/2019/08/02/coredns-1.6.1-release/
* https://coredns.io/2019/08/13/coredns-1.6.2-release/